### PR TITLE
Refactor: extrair import/renderer, adicionar debounce de preview e checagem de dependências

### DIFF
--- a/qr_generator.py
+++ b/qr_generator.py
@@ -86,13 +86,18 @@ class QRCodeGenerator:
         self.arquivo_fonte = ""
         self.preview_image_ref = None
         self._preview_backend_error_shown = False
+        self._preview_after_id = None
+        self.preview_debounce_ms = 250
+        self.pdf_export_disponivel = False
+        self.barcode_disponivel = False
+        self.motivos_dependencias_indisponiveis = []
         self.cancelar_evento = threading.Event()
         self.sections = InterfaceSections()
 
-        self.qr_width_cm = tk.DoubleVar(value=4.0)
-        self.qr_height_cm = tk.DoubleVar(value=4.0)
-        self.barcode_width_cm = tk.DoubleVar(value=8.0)
-        self.barcode_height_cm = tk.DoubleVar(value=3.0)
+        self.qr_width_cm = tk.StringVar(value="4.0")
+        self.qr_height_cm = tk.StringVar(value="4.0")
+        self.barcode_width_cm = tk.StringVar(value="8.0")
+        self.barcode_height_cm = tk.StringVar(value="3.0")
         self.keep_qr_ratio = tk.BooleanVar(value=True)
         self.keep_barcode_ratio = tk.BooleanVar(value=True)
         self.qr_foreground_color = tk.StringVar(value="black")
@@ -103,8 +108,8 @@ class QRCodeGenerator:
         self.barcode_model = tk.StringVar(value="code128")
         self.preview_zoom = tk.StringVar(value="100%")
         self.preview_preset = tk.StringVar(value="A4")
-        self.preview_margin_cm = tk.DoubleVar(value=2.0)
-        self.preview_spacing_cm = tk.DoubleVar(value=1.0)
+        self.preview_margin_cm = tk.StringVar(value="2.0")
+        self.preview_spacing_cm = tk.StringVar(value="1.0")
         self.impressora_var = tk.StringVar(value="")
         self.copias_impressao = tk.IntVar(value=1)
         self.impressora_status_var = tk.StringVar(value="")
@@ -129,6 +134,7 @@ class QRCodeGenerator:
         self.estado_atual = EstadoAplicacao.IDLE
 
         self._configurar_estilos()
+        self._verificar_dependencias_essenciais()
         self.root.title(self._t("app.title", "QR / Código de Barras Generator"))
         self.barcode_model_options = self.controller.obter_modelos_barcode()
         self.barcode_label_to_key = {rotulo: chave for chave, rotulo in self.barcode_model_options}
@@ -199,6 +205,26 @@ class QRCodeGenerator:
             background=[("!disabled", "#2563eb")],
         )
 
+    def _verificar_dependencias_essenciais(self):
+        self.motivos_dependencias_indisponiveis = []
+
+        try:
+            from reportlab.pdfgen import canvas as _pdf_canvas  # noqa: F401
+
+            self.pdf_export_disponivel = True
+        except Exception:
+            self.pdf_export_disponivel = False
+            self.motivos_dependencias_indisponiveis.append("PDF/Impressão indisponível (faltando reportlab).")
+
+        try:
+            from reportlab.graphics import renderPM as _render_pm  # noqa: F401
+            from reportlab.graphics.barcode import createBarcodeDrawing as _barcode_factory  # noqa: F401
+
+            self.barcode_disponivel = True
+        except Exception:
+            self.barcode_disponivel = False
+            self.motivos_dependencias_indisponiveis.append("Código de barras indisponível (faltando backend renderPM).")
+
     def _criar_interface(self):
         conteudo = ttk.Frame(self.root, padding=self.space_md)
         conteudo.pack(fill="x")
@@ -241,40 +267,49 @@ class QRCodeGenerator:
         self.formato_combo.set(self.formato_saida.get())
         self.formato_combo.bind("<<ComboboxSelected>>", self._ao_alterar_formato_saida)
         ttk.Label(self.config_frame, text=self._t("hint.svg_only_qr", "(SVG apenas para QR)"), style="SectionHint.TLabel").grid(row=0, column=2, padx=(0, self.space_sm), sticky="w")
-        self.formato_combo.configure(values=["pdf", "png", "zip", "svg", "imprimir"])
+        formatos_disponiveis = ["png", "zip", "svg"]
+        if self.pdf_export_disponivel:
+            formatos_disponiveis = ["pdf", "png", "zip", "svg", "imprimir"]
+        self.formato_combo.configure(values=formatos_disponiveis)
+        if self.formato_saida.get() not in formatos_disponiveis:
+            self.formato_saida.set("png")
+            self.formato_combo.set("png")
 
         ttk.Label(self.config_frame, text="QR (cm LxA):").grid(row=1, column=0, sticky="e", padx=(0, 5), pady=5)
-        self.qr_w_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=30.0, increment=0.1, textvariable=self.qr_width_cm, width=5, command=self.atualizar_preview, style="App.TSpinbox")
+        self.qr_w_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=30.0, increment=0.1, textvariable=self.qr_width_cm, width=5, command=self.solicitar_atualizacao_preview, style="App.TSpinbox")
         self.qr_w_spin.grid(row=1, column=1, padx=(0, 2), pady=5, sticky="w")
-        self.qr_h_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=30.0, increment=0.1, textvariable=self.qr_height_cm, width=5, command=self.atualizar_preview, style="App.TSpinbox")
+        self.qr_h_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=30.0, increment=0.1, textvariable=self.qr_height_cm, width=5, command=self.solicitar_atualizacao_preview, style="App.TSpinbox")
         self.qr_h_spin.grid(row=1, column=2, padx=(2, 5), pady=5, sticky="w")
-        ttk.Checkbutton(self.config_frame, text="Manter proporção QR", variable=self.keep_qr_ratio, command=self.atualizar_preview).grid(row=1, column=3, padx=5, pady=5, sticky="w")
+        ttk.Checkbutton(self.config_frame, text="Manter proporção QR", variable=self.keep_qr_ratio, command=self.solicitar_atualizacao_preview).grid(row=1, column=3, padx=5, pady=5, sticky="w")
 
         ttk.Label(self.config_frame, text="Barra (cm LxA):").grid(row=2, column=0, sticky="e", padx=(0, 5), pady=5)
-        self.bar_w_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=40.0, increment=0.1, textvariable=self.barcode_width_cm, width=5, command=self.atualizar_preview, style="App.TSpinbox")
+        self.bar_w_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=40.0, increment=0.1, textvariable=self.barcode_width_cm, width=5, command=self.solicitar_atualizacao_preview, style="App.TSpinbox")
         self.bar_w_spin.grid(row=2, column=1, padx=(0, 2), pady=5, sticky="w")
-        self.bar_h_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=20.0, increment=0.1, textvariable=self.barcode_height_cm, width=5, command=self.atualizar_preview, style="App.TSpinbox")
+        self.bar_h_spin = ttk.Spinbox(self.config_frame, from_=1.0, to=20.0, increment=0.1, textvariable=self.barcode_height_cm, width=5, command=self.solicitar_atualizacao_preview, style="App.TSpinbox")
         self.bar_h_spin.grid(row=2, column=2, padx=(2, 5), pady=5, sticky="w")
-        ttk.Checkbutton(self.config_frame, text="Manter proporção Barra", variable=self.keep_barcode_ratio, command=self.atualizar_preview).grid(row=2, column=3, padx=5, pady=5, sticky="w")
+        ttk.Checkbutton(self.config_frame, text="Manter proporção Barra", variable=self.keep_barcode_ratio, command=self.solicitar_atualizacao_preview).grid(row=2, column=3, padx=5, pady=5, sticky="w")
 
         for spin in (self.qr_w_spin, self.qr_h_spin, self.bar_w_spin, self.bar_h_spin):
-            spin.bind("<FocusOut>", lambda _e: self.atualizar_preview())
+            spin.bind("<FocusOut>", lambda _e: self.solicitar_atualizacao_preview())
+            spin.bind("<KeyRelease>", lambda _e: self.solicitar_atualizacao_preview())
 
         ttk.Label(self.config_frame, text=self._t("label.type", "Tipo:")).grid(row=3, column=0, sticky="e", padx=(0, 5), pady=5)
-        ttk.Radiobutton(
+        self.tipo_qr_radio = ttk.Radiobutton(
             self.config_frame,
             text=self._t("type.qr", "QR Code"),
             variable=self.tipo_codigo,
             value="qrcode",
             command=self._ao_alterar_tipo_codigo,
-        ).grid(row=3, column=1, sticky="w")
-        ttk.Radiobutton(
+        )
+        self.tipo_qr_radio.grid(row=3, column=1, sticky="w")
+        self.tipo_barcode_radio = ttk.Radiobutton(
             self.config_frame,
             text=self._t("type.barcode", "Código de Barras"),
             variable=self.tipo_codigo,
             value="barcode",
             command=self._ao_alterar_tipo_codigo,
-        ).grid(row=3, column=2, sticky="w")
+        )
+        self.tipo_barcode_radio.grid(row=3, column=2, sticky="w")
         ttk.Label(self.config_frame, text=self._t("label.barcode_model", "Modelo de etiqueta:")).grid(row=3, column=3, sticky="e", padx=(0, 5), pady=5)
         self.barcode_model_combo = ttk.Combobox(
             self.config_frame,
@@ -286,6 +321,13 @@ class QRCodeGenerator:
         self.barcode_model_combo.grid(row=3, column=4, padx=(2, 5), pady=5, sticky="w")
         self.barcode_model_combo.set(self.barcode_key_to_label.get(self.barcode_model.get(), "Código 128"))
         self.barcode_model_combo.bind("<<ComboboxSelected>>", self._ao_alterar_modelo_barcode)
+        aviso_dependencias = "Todos os recursos disponíveis."
+        if self.motivos_dependencias_indisponiveis:
+            aviso_dependencias = " | ".join(self.motivos_dependencias_indisponiveis)
+        self.dependency_status_var = tk.StringVar(value=aviso_dependencias)
+        ttk.Label(self.config_frame, textvariable=self.dependency_status_var, style="Muted.TLabel").grid(
+            row=7, column=0, columnspan=5, sticky="w", padx=5, pady=(2, 0)
+        )
 
         ttk.Label(self.config_frame, text=self._t("label.data_mode", "Modo de dados:")).grid(row=4, column=0, sticky="e", padx=(0, 5), pady=5)
         ttk.Radiobutton(
@@ -317,6 +359,7 @@ class QRCodeGenerator:
 
         self.atualizar_controles_formato()
         self._atualizar_controles_tipo_codigo()
+        self._aplicar_disponibilidade_dependencias()
 
         self.impressao_frame = ttk.LabelFrame(self.config_frame, text="Configuração de impressão", padding=self.space_sm)
         self.impressao_frame.grid(row=6, column=0, columnspan=4, sticky="ew", padx=5, pady=(self.space_sm, 0))
@@ -405,11 +448,11 @@ class QRCodeGenerator:
             textvariable=self.preview_preset,
             state="readonly",
             width=20,
-            values=["A4", "Etiqueta 40x20 mm", "Etiqueta 60x40 mm"],
+            values=["A4", "Etiqueta 8x10.5 cm", "Etiqueta 60x40 mm"],
             style="App.TCombobox",
         )
         self.preview_preset_combo.pack(side="left", padx=(self.space_sm, self.space_md))
-        self.preview_preset_combo.bind("<<ComboboxSelected>>", lambda _e: self.atualizar_preview())
+        self.preview_preset_combo.bind("<<ComboboxSelected>>", lambda _e: self.solicitar_atualizacao_preview())
 
         ttk.Label(preview_toolbar, text="Margem (cm):").pack(side="left")
         self.preview_margin_spin = ttk.Spinbox(
@@ -419,7 +462,7 @@ class QRCodeGenerator:
             increment=0.1,
             textvariable=self.preview_margin_cm,
             width=5,
-            command=self.atualizar_preview,
+            command=self.solicitar_atualizacao_preview,
             style="App.TSpinbox",
         )
         self.preview_margin_spin.pack(side="left", padx=(self.space_sm, self.space_md))
@@ -432,7 +475,7 @@ class QRCodeGenerator:
             increment=0.1,
             textvariable=self.preview_spacing_cm,
             width=5,
-            command=self.atualizar_preview,
+            command=self.solicitar_atualizacao_preview,
             style="App.TSpinbox",
         )
         self.preview_spacing_spin.pack(side="left", padx=(self.space_sm, self.space_md))
@@ -447,9 +490,11 @@ class QRCodeGenerator:
             style="App.TCombobox",
         )
         self.preview_zoom_combo.pack(side="left", padx=(self.space_sm, 0))
-        self.preview_zoom_combo.bind("<<ComboboxSelected>>", lambda _e: self.atualizar_preview())
-        self.preview_margin_spin.bind("<FocusOut>", lambda _e: self.atualizar_preview())
-        self.preview_spacing_spin.bind("<FocusOut>", lambda _e: self.atualizar_preview())
+        self.preview_zoom_combo.bind("<<ComboboxSelected>>", lambda _e: self.solicitar_atualizacao_preview())
+        self.preview_margin_spin.bind("<FocusOut>", lambda _e: self.solicitar_atualizacao_preview())
+        self.preview_spacing_spin.bind("<FocusOut>", lambda _e: self.solicitar_atualizacao_preview())
+        self.preview_margin_spin.bind("<KeyRelease>", lambda _e: self.solicitar_atualizacao_preview())
+        self.preview_spacing_spin.bind("<KeyRelease>", lambda _e: self.solicitar_atualizacao_preview())
 
         self.preview_escala_var = tk.StringVar(value="Escala visual: 100%")
         ttk.Label(preview_toolbar, textvariable=self.preview_escala_var, style="SectionHint.TLabel").pack(side="right")
@@ -545,30 +590,52 @@ class QRCodeGenerator:
         self._atualizar_stepper_visual()
 
     def _ao_selecionar_coluna(self, _e=None):
-        self.atualizar_preview()
+        self.solicitar_atualizacao_preview()
         self._atualizar_stepper_visual()
 
     def _ao_alterar_formato_saida(self, _e=None):
+        formatos_disponiveis = set(self.formato_combo.cget("values"))
+        if self.formato_saida.get() not in formatos_disponiveis:
+            self.formato_saida.set("png")
+            self.formato_combo.set("png")
         self._atualizar_controles_impressao()
         self._aplicar_estado_ui()
 
     def _ao_alterar_tipo_codigo(self):
         self._atualizar_controles_tipo_codigo()
-        self.atualizar_preview()
+        self.solicitar_atualizacao_preview()
 
     def _ao_alterar_modelo_barcode(self, _e=None):
         chave = self.barcode_label_to_key.get(self.barcode_model_combo.get())
         if chave:
             self.barcode_model.set(chave)
-        self.atualizar_preview()
+        self.solicitar_atualizacao_preview()
 
     def _atualizar_controles_tipo_codigo(self):
+        if not self.barcode_disponivel:
+            self.tipo_codigo.set("qrcode")
+            self.barcode_model_combo.configure(state="disabled")
+            return
         if self.tipo_codigo.get() == "barcode":
             self.barcode_model_combo.configure(state="readonly")
             if self.barcode_model.get() in self.barcode_key_to_label:
                 self.barcode_model_combo.set(self.barcode_key_to_label[self.barcode_model.get()])
         else:
             self.barcode_model_combo.configure(state="disabled")
+
+    def _aplicar_disponibilidade_dependencias(self):
+        if hasattr(self, "tipo_barcode_radio"):
+            self.tipo_barcode_radio.configure(state="normal" if self.barcode_disponivel else "disabled")
+        if not self.barcode_disponivel:
+            self.tipo_codigo.set("qrcode")
+
+        formatos_disponiveis = ["png", "zip", "svg"]
+        if self.pdf_export_disponivel:
+            formatos_disponiveis = ["pdf", "png", "zip", "svg", "imprimir"]
+        self.formato_combo.configure(values=formatos_disponiveis)
+        if self.formato_saida.get() not in formatos_disponiveis:
+            self.formato_saida.set("png")
+            self.formato_combo.set("png")
 
     def _listar_impressoras_windows(self):
         if not sys.platform.startswith("win"):
@@ -800,7 +867,8 @@ class QRCodeGenerator:
 
         self._atualizar_controles_impressao()
         if hasattr(self, "barcode_model_combo"):
-            estado_barcode = "readonly" if (self.tipo_codigo.get() == "barcode" and not bloqueado) else "disabled"
+            barcode_ativo = self.barcode_disponivel and self.tipo_codigo.get() == "barcode"
+            estado_barcode = "readonly" if (barcode_ativo and not bloqueado) else "disabled"
             self.barcode_model_combo.configure(state=estado_barcode)
         self._atualizar_stepper_visual()
 
@@ -857,12 +925,26 @@ class QRCodeGenerator:
     def _obter_valores_coluna(self, tabela, coluna):
         return self.controller.obter_valores_coluna(tabela, coluna)
 
+    def _parse_float_input(self, valor, nome_campo: str) -> float:
+        if isinstance(valor, str):
+            texto = valor.strip().replace(",", ".")
+        else:
+            texto = str(valor)
+        try:
+            return float(texto)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(self._t("validation.invalid_number", "Valor inválido para {campo}: {valor}", campo=nome_campo, valor=valor)) from exc
+
     def _build_config(self) -> GeracaoConfig:
+        if self.tipo_codigo.get() == "barcode" and not self.barcode_disponivel:
+            raise ValueError("Código de barras indisponível neste ambiente (dependência renderPM ausente).")
+        if self.formato_saida.get() in {"pdf", "imprimir"} and not self.pdf_export_disponivel:
+            raise ValueError("Formato PDF/Impressão indisponível neste ambiente (dependência reportlab ausente).")
         return GeracaoConfig(
-            qr_width_cm=float(self.qr_width_cm.get()),
-            qr_height_cm=float(self.qr_height_cm.get()),
-            barcode_width_cm=float(self.barcode_width_cm.get()),
-            barcode_height_cm=float(self.barcode_height_cm.get()),
+            qr_width_cm=self._parse_float_input(self.qr_width_cm.get(), self._t("labels.qr_width", "Largura QR (cm)")),
+            qr_height_cm=self._parse_float_input(self.qr_height_cm.get(), self._t("labels.qr_height", "Altura QR (cm)")),
+            barcode_width_cm=self._parse_float_input(self.barcode_width_cm.get(), self._t("labels.barcode_width", "Largura Código de Barras (cm)")),
+            barcode_height_cm=self._parse_float_input(self.barcode_height_cm.get(), self._t("labels.barcode_height", "Altura Código de Barras (cm)")),
             keep_qr_ratio=bool(self.keep_qr_ratio.get()),
             keep_barcode_ratio=bool(self.keep_barcode_ratio.get()),
             foreground=self.qr_foreground_color.get(),
@@ -907,15 +989,15 @@ class QRCodeGenerator:
 
     def _gerar_preview_documento(self, codigos, cfg: GeracaoConfig) -> Image.Image:
         preset = self.preview_preset.get()
-        if preset == "Etiqueta 40x20 mm":
-            largura, altura = int(40 * mm), int(20 * mm)
+        if preset == "Etiqueta 8x10.5 cm":
+            largura, altura = int(80 * mm), int(105 * mm)
         elif preset == "Etiqueta 60x40 mm":
             largura, altura = int(60 * mm), int(40 * mm)
         else:
             largura, altura = map(int, A4)
 
-        margem_cm = max(0.2, float(self.preview_margin_cm.get()))
-        espaco_cm = max(0.1, float(self.preview_spacing_cm.get()))
+        margem_cm = max(0.2, self._parse_float_input(self.preview_margin_cm.get(), self._t("labels.preview_margin", "Margem (cm)")))
+        espaco_cm = max(0.1, self._parse_float_input(self.preview_spacing_cm.get(), self._t("labels.preview_spacing", "Espaçamento (cm)")))
         margem_px = int(margem_cm * 10 * mm)
         espaco_px = int(espaco_cm * 10 * mm)
 
@@ -980,8 +1062,8 @@ class QRCodeGenerator:
         return fundo
 
     def atualizar_preview(self):
-        cfg = self._build_config()
         try:
+            cfg = self._build_config()
             codigos_preview = self._extrair_codigos_preview()
             if codigos_preview:
                 img = self._gerar_preview_documento(codigos_preview, cfg)
@@ -1018,6 +1100,15 @@ class QRCodeGenerator:
             if not self._preview_backend_error_shown:
                 messagebox.showwarning(self._t("dialog.title.preview", "Pré-visualização"), self._t("preview.update_error", "Não foi possível atualizar o preview:\n{erro}", erro=exc))
                 self._preview_backend_error_shown = True
+
+    def solicitar_atualizacao_preview(self, *_args):
+        if self._preview_after_id is not None:
+            self.root.after_cancel(self._preview_after_id)
+        self._preview_after_id = self.root.after(self.preview_debounce_ms, self._executar_preview_debounced)
+
+    def _executar_preview_debounced(self):
+        self._preview_after_id = None
+        self.atualizar_preview()
 
     def gerar_imagens(self, codigos, formato, destino, emitir_sucesso=True):
         try:
@@ -1277,7 +1368,7 @@ class QRCodeGenerator:
                     self._atualizar_resumo_painel(processado=0, ignorados=0, caminho="", job_id="")
                     if colunas:
                         self.column_combo.set(colunas[0])
-                    self.atualizar_preview()
+                    self.solicitar_atualizacao_preview()
                     self._transicionar_estado(EstadoAplicacao.READY)
                 elif msg["tipo"] == "carregamento_erro":
                     self.progress_bar.stop()

--- a/services/codigo_service.py
+++ b/services/codigo_service.py
@@ -1,148 +1,70 @@
-import csv
-
-import qrcode
-from PIL import Image
-
 from models.geracao_config import GeracaoConfig
+from services.data_importer import DataImporter
+from services.renderers import BarcodeRenderer, QRCodeRenderer
 
 
 class CodigoService:
-    """Camada de negócio para carga, validação e geração de códigos."""
+    """Camada de negócio orquestrando importação, validação e renderização."""
 
     DPI_PADRAO = 200
-    BARCODE_MODELOS_SUPORTADOS = {
-        "ean13": ("Código de Barras EAN-13", "EAN13"),
-        "dun14": ("Código de Barras DUN-14", "I2of5"),
-        "upca": ("UPC ou Código Universal de Produto", "UPCA"),
-        "code11": ("Code 11", "Code11"),
-        "code39": ("Code 39", "Standard39"),
-        "code93": ("Code 93", "Standard93"),
-        "ean8": ("EAN-8", "EAN8"),
-        "interleaved2of5": ("Intercalado 2 de 5", "I2of5"),
-        "code128": ("Código 128", "Code128"),
-        "gs1128": ("GS1-128", "Code128"),
-        "codabar": ("Codabar", "Codabar"),
-        "datamatrix": ("Data Matrix", "ECC200DataMatrix"),
-    }
+    BARCODE_MODELOS_SUPORTADOS = BarcodeRenderer.MODELOS_SUPORTADOS
+
+    def __init__(self):
+        self.data_importer = DataImporter()
+        self.qr_renderer = QRCodeRenderer(self.DPI_PADRAO)
+        self.barcode_renderer = BarcodeRenderer(self.DPI_PADRAO)
 
     @staticmethod
     def formatar_excecao(exc: Exception, contexto: str) -> str:
-        return f"{contexto}: {exc}"
+        return DataImporter.formatar_excecao(exc, contexto)
 
-    @staticmethod
-    def carregar_tabela(caminho):
-        if caminho.lower().endswith('.csv'):
-            try:
-                import pandas as pd
-                return pd.read_csv(caminho)
-            except ImportError:
-                with open(caminho, newline='', encoding='utf-8-sig') as f:
-                    return list(csv.DictReader(f))
-            except (OSError, UnicodeDecodeError, ValueError) as exc:
-                raise RuntimeError(CodigoService.formatar_excecao(exc, 'Falha ao carregar CSV')) from exc
+    def carregar_tabela(self, caminho):
+        return self.data_importer.carregar_tabela(caminho)
 
-        try:
-            import pandas as pd
-            return pd.read_excel(caminho)
-        except ImportError as exc:
-            raise RuntimeError(
-                "Falha ao carregar Excel. Instale/repare 'pandas', 'numpy' e 'openpyxl' no ambiente."
-            ) from exc
-        except (OSError, ValueError) as exc:
-            raise RuntimeError(CodigoService.formatar_excecao(exc, 'Falha ao carregar Excel')) from exc
+    def obter_colunas(self, tabela):
+        return self.data_importer.obter_colunas(tabela)
 
-    @staticmethod
-    def obter_colunas(tabela):
-        if tabela is None:
-            return []
-        if hasattr(tabela, 'columns'):
-            return list(tabela.columns)
-        if isinstance(tabela, list) and tabela:
-            return list(tabela[0].keys())
-        return []
-
-    @staticmethod
-    def obter_valores_coluna(tabela, coluna):
-        if hasattr(tabela, '__getitem__') and hasattr(tabela, 'columns'):
-            return [str(v) for v in tabela[coluna].dropna().tolist()]
-        if isinstance(tabela, list):
-            vals = []
-            for linha in tabela:
-                valor = linha.get(coluna)
-                if valor is not None and str(valor).strip() != '':
-                    vals.append(str(valor))
-            return vals
-        return []
+    def obter_valores_coluna(self, tabela, coluna):
+        return self.data_importer.obter_valores_coluna(tabela, coluna)
 
     @staticmethod
     def sanitizar_nome_arquivo(nome: str, fallback: str) -> str:
-        nome_limpo = ''.join('_' if c in '\\/:*?"<>|' else c for c in str(nome))
-        nome_limpo = nome_limpo.strip().strip('.')
+        nome_limpo = "".join("_" if c in '\\/:*?"<>|' else c for c in str(nome))
+        nome_limpo = nome_limpo.strip().strip(".")
         return nome_limpo or fallback
 
     @staticmethod
     def normalizar_dado(valor: str, cfg: GeracaoConfig) -> str:
         valor = str(valor)
-        if cfg.modo == 'numerico':
+        if cfg.modo == "numerico":
             return f"{cfg.prefixo}{valor}{cfg.sufixo}"
         return valor
 
     @staticmethod
-    def _cm_para_px(cm: float, dpi: int = DPI_PADRAO) -> int:
-        return max(1, int(round((cm / 2.54) * dpi)))
-
-    @staticmethod
-    def _resize_with_ratio(img: Image.Image, width_px: int, height_px: int, keep_ratio: bool) -> Image.Image:
-        width_px = max(1, width_px)
-        height_px = max(1, height_px)
-        if not keep_ratio:
-            return img.resize((width_px, height_px), Image.Resampling.LANCZOS)
-
-        base = img.copy()
-        base.thumbnail((width_px, height_px), Image.Resampling.LANCZOS)
-        canvas = Image.new('RGB', (width_px, height_px), 'white')
-        x = (width_px - base.width) // 2
-        y = (height_px - base.height) // 2
-        canvas.paste(base, (x, y))
-        return canvas
-
-    @staticmethod
     def obter_modelos_barcode():
-        return [(chave, rotulo) for chave, (rotulo, _nome_reportlab) in CodigoService.BARCODE_MODELOS_SUPORTADOS.items()]
-
-    @staticmethod
-    def _validar_modelo_barcode(dado: str, modelo: str):
-        if modelo == "ean13" and (not dado.isdigit() or len(dado) not in (12, 13)):
-            raise ValueError("EAN-13 exige apenas dígitos com 12 ou 13 caracteres.")
-        if modelo == "ean8" and (not dado.isdigit() or len(dado) not in (7, 8)):
-            raise ValueError("EAN-8 exige apenas dígitos com 7 ou 8 caracteres.")
-        if modelo == "upca" and (not dado.isdigit() or len(dado) not in (11, 12)):
-            raise ValueError("UPC-A exige apenas dígitos com 11 ou 12 caracteres.")
-        if modelo == "dun14" and (not dado.isdigit() or len(dado) != 14):
-            raise ValueError("DUN-14 exige exatamente 14 dígitos numéricos.")
-        if modelo == "interleaved2of5":
-            if not dado.isdigit():
-                raise ValueError("Intercalado 2 de 5 exige apenas dígitos.")
-            if len(dado) % 2 != 0:
-                raise ValueError("Intercalado 2 de 5 exige quantidade par de dígitos.")
+        return [
+            (chave, rotulo)
+            for chave, (rotulo, _nome_reportlab) in CodigoService.BARCODE_MODELOS_SUPORTADOS.items()
+        ]
 
     @staticmethod
     def validar_parametros_geracao(codigos, cfg: GeracaoConfig):
         if not isinstance(codigos, list) or not codigos:
-            raise ValueError('Nenhum código válido foi encontrado para geração.')
+            raise ValueError("Nenhum código válido foi encontrado para geração.")
         if len(codigos) > cfg.max_codigos_por_lote:
-            raise ValueError(f'Limite excedido: máximo de {cfg.max_codigos_por_lote} códigos por geração.')
+            raise ValueError(f"Limite excedido: máximo de {cfg.max_codigos_por_lote} códigos por geração.")
 
         if cfg.qr_width_cm <= 0 or cfg.qr_height_cm <= 0:
-            raise ValueError('Tamanho de QR inválido. Informe largura/altura em cm maiores que zero.')
+            raise ValueError("Tamanho de QR inválido. Informe largura/altura em cm maiores que zero.")
         if cfg.barcode_width_cm <= 0 or cfg.barcode_height_cm <= 0:
-            raise ValueError('Tamanho de código de barras inválido. Informe largura/altura em cm maiores que zero.')
+            raise ValueError(
+                "Tamanho de código de barras inválido. Informe largura/altura em cm maiores que zero."
+            )
 
-        # limites práticos
         if cfg.qr_width_cm > 30 or cfg.qr_height_cm > 30:
-            raise ValueError('Tamanho de QR inválido. Use valores até 30 cm.')
+            raise ValueError("Tamanho de QR inválido. Use valores até 30 cm.")
         if cfg.barcode_width_cm > 40 or cfg.barcode_height_cm > 20:
-            raise ValueError('Tamanho de código de barras inválido. Use até 40x20 cm.')
+            raise ValueError("Tamanho de código de barras inválido. Use até 40x20 cm.")
 
         validos = []
         invalidos = 0
@@ -151,66 +73,22 @@ class CodigoService:
             if not dado or not dado.strip() or len(dado) > cfg.max_tamanho_dado:
                 invalidos += 1
                 continue
-            if cfg.tipo_codigo == 'barcode' and any(ord(ch) < 32 for ch in dado):
+            if cfg.tipo_codigo == "barcode" and any(ord(ch) < 32 for ch in dado):
                 invalidos += 1
                 continue
             if cfg.tipo_codigo == "barcode":
                 try:
-                    CodigoService._validar_modelo_barcode(dado.strip(), cfg.barcode_model)
+                    BarcodeRenderer.validar_modelo(dado.strip(), cfg.barcode_model)
                 except ValueError:
                     invalidos += 1
                     continue
             validos.append(str(bruto))
 
         if not validos:
-            raise ValueError('Todos os dados foram rejeitados pela validação de entrada.')
+            raise ValueError("Todos os dados foram rejeitados pela validação de entrada.")
         return validos, invalidos
 
-    @staticmethod
-    def _gerar_barcode_pil(dado: str, cfg: GeracaoConfig) -> Image.Image:
-        width_px = CodigoService._cm_para_px(cfg.barcode_width_cm)
-        height_px = CodigoService._cm_para_px(cfg.barcode_height_cm)
-        dado_limpo = dado.strip()
-        modelo = cfg.barcode_model or "code128"
-        if modelo not in CodigoService.BARCODE_MODELOS_SUPORTADOS:
-            raise RuntimeError(f"Modelo de código de barras não suportado: {modelo}")
-        CodigoService._validar_modelo_barcode(dado_limpo, modelo)
-        _rotulo, nome_reportlab = CodigoService.BARCODE_MODELOS_SUPORTADOS[modelo]
-
-        try:
-            from reportlab.graphics import renderPM
-            from reportlab.graphics.barcode import createBarcodeDrawing
-            from reportlab.lib.units import mm
-
-            opcoes = {"value": dado_limpo}
-            if nome_reportlab != "ECC200DataMatrix":
-                opcoes.update({"barHeight": 20 * mm, "barWidth": 0.45, "humanReadable": True})
-            desenho = createBarcodeDrawing(nome_reportlab, **opcoes)
-            img = renderPM.drawToPIL(desenho, dpi=CodigoService.DPI_PADRAO).convert('RGB')
-            return CodigoService._resize_with_ratio(img, width_px, height_px, cfg.keep_barcode_ratio)
-        except Exception as exc:
-            raise RuntimeError(
-                "Geração de código de barras indisponível: habilite o backend renderPM do ReportLab."
-            ) from exc
-
-    @staticmethod
-    def gerar_imagem_obj(dado: str, cfg: GeracaoConfig) -> Image.Image:
-        if cfg.tipo_codigo == 'barcode':
-            return CodigoService._gerar_barcode_pil(dado, cfg)
-
-        qr = qrcode.QRCode(box_size=10, border=2)
-        qr.add_data(dado)
-        qr.make(fit=True)
-        img = qr.make_image(fill_color=cfg.foreground, back_color=cfg.background)
-        if hasattr(img, 'get_image'):
-            img = img.get_image()
-        if not isinstance(img, Image.Image):
-            img = Image.open(io.BytesIO(img.tobytes()))
-
-        qr_img = img.convert('RGB')
-        return CodigoService._resize_with_ratio(
-            qr_img,
-            CodigoService._cm_para_px(cfg.qr_width_cm),
-            CodigoService._cm_para_px(cfg.qr_height_cm),
-            cfg.keep_qr_ratio,
-        )
+    def gerar_imagem_obj(self, dado: str, cfg: GeracaoConfig):
+        if cfg.tipo_codigo == "barcode":
+            return self.barcode_renderer.render(dado, cfg)
+        return self.qr_renderer.render(dado, cfg)

--- a/services/data_importer.py
+++ b/services/data_importer.py
@@ -1,0 +1,55 @@
+import csv
+
+
+class DataImporter:
+    """Responsável por carregar tabelas e extrair colunas/valores."""
+
+    @staticmethod
+    def formatar_excecao(exc: Exception, contexto: str) -> str:
+        return f"{contexto}: {exc}"
+
+    def carregar_tabela(self, caminho):
+        if caminho.lower().endswith(".csv"):
+            try:
+                import pandas as pd
+
+                return pd.read_csv(caminho)
+            except ImportError:
+                with open(caminho, newline="", encoding="utf-8-sig") as arquivo:
+                    return list(csv.DictReader(arquivo))
+            except (OSError, UnicodeDecodeError, ValueError) as exc:
+                raise RuntimeError(self.formatar_excecao(exc, "Falha ao carregar CSV")) from exc
+
+        try:
+            import pandas as pd
+
+            return pd.read_excel(caminho)
+        except ImportError as exc:
+            raise RuntimeError(
+                "Falha ao carregar Excel. Instale/repare 'pandas', 'numpy' e 'openpyxl' no ambiente."
+            ) from exc
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(self.formatar_excecao(exc, "Falha ao carregar Excel")) from exc
+
+    @staticmethod
+    def obter_colunas(tabela):
+        if tabela is None:
+            return []
+        if hasattr(tabela, "columns"):
+            return list(tabela.columns)
+        if isinstance(tabela, list) and tabela:
+            return list(tabela[0].keys())
+        return []
+
+    @staticmethod
+    def obter_valores_coluna(tabela, coluna):
+        if hasattr(tabela, "__getitem__") and hasattr(tabela, "columns"):
+            return [str(v) for v in tabela[coluna].dropna().tolist()]
+        if isinstance(tabela, list):
+            vals = []
+            for linha in tabela:
+                valor = linha.get(coluna)
+                if valor is not None and str(valor).strip() != "":
+                    vals.append(str(valor))
+            return vals
+        return []

--- a/services/renderers.py
+++ b/services/renderers.py
@@ -1,0 +1,108 @@
+import qrcode
+from PIL import Image
+
+
+class ImageResizer:
+    @staticmethod
+    def resize_with_ratio(img: Image.Image, width_px: int, height_px: int, keep_ratio: bool) -> Image.Image:
+        width_px = max(1, width_px)
+        height_px = max(1, height_px)
+        if not keep_ratio:
+            return img.resize((width_px, height_px), Image.Resampling.LANCZOS)
+
+        base = img.copy()
+        base.thumbnail((width_px, height_px), Image.Resampling.LANCZOS)
+        canvas = Image.new("RGB", (width_px, height_px), "white")
+        x = (width_px - base.width) // 2
+        y = (height_px - base.height) // 2
+        canvas.paste(base, (x, y))
+        return canvas
+
+
+class QRCodeRenderer:
+    def __init__(self, dpi_padrao: int = 200):
+        self.dpi_padrao = dpi_padrao
+
+    def _cm_para_px(self, cm: float) -> int:
+        return max(1, int(round((cm / 2.54) * self.dpi_padrao)))
+
+    def render(self, dado: str, cfg) -> Image.Image:
+        qr = qrcode.QRCode(box_size=10, border=2)
+        qr.add_data(dado)
+        qr.make(fit=True)
+        img = qr.make_image(fill_color=cfg.foreground, back_color=cfg.background)
+        if hasattr(img, "get_image"):
+            img = img.get_image()
+
+        qr_img = img.convert("RGB")
+        return ImageResizer.resize_with_ratio(
+            qr_img,
+            self._cm_para_px(cfg.qr_width_cm),
+            self._cm_para_px(cfg.qr_height_cm),
+            cfg.keep_qr_ratio,
+        )
+
+
+class BarcodeRenderer:
+    MODELOS_SUPORTADOS = {
+        "ean13": ("Código de Barras EAN-13", "EAN13"),
+        "dun14": ("Código de Barras DUN-14", "I2of5"),
+        "upca": ("UPC ou Código Universal de Produto", "UPCA"),
+        "code11": ("Code 11", "Code11"),
+        "code39": ("Code 39", "Standard39"),
+        "code93": ("Code 93", "Standard93"),
+        "ean8": ("EAN-8", "EAN8"),
+        "interleaved2of5": ("Intercalado 2 de 5", "I2of5"),
+        "code128": ("Código 128", "Code128"),
+        "gs1128": ("GS1-128", "Code128"),
+        "codabar": ("Codabar", "Codabar"),
+        "datamatrix": ("Data Matrix", "ECC200DataMatrix"),
+    }
+
+    def __init__(self, dpi_padrao: int = 200):
+        self.dpi_padrao = dpi_padrao
+
+    def _cm_para_px(self, cm: float) -> int:
+        return max(1, int(round((cm / 2.54) * self.dpi_padrao)))
+
+    @staticmethod
+    def validar_modelo(dado: str, modelo: str):
+        if modelo == "ean13" and (not dado.isdigit() or len(dado) not in (12, 13)):
+            raise ValueError("EAN-13 exige apenas dígitos com 12 ou 13 caracteres.")
+        if modelo == "ean8" and (not dado.isdigit() or len(dado) not in (7, 8)):
+            raise ValueError("EAN-8 exige apenas dígitos com 7 ou 8 caracteres.")
+        if modelo == "upca" and (not dado.isdigit() or len(dado) not in (11, 12)):
+            raise ValueError("UPC-A exige apenas dígitos com 11 ou 12 caracteres.")
+        if modelo == "dun14" and (not dado.isdigit() or len(dado) != 14):
+            raise ValueError("DUN-14 exige exatamente 14 dígitos numéricos.")
+        if modelo == "interleaved2of5":
+            if not dado.isdigit():
+                raise ValueError("Intercalado 2 de 5 exige apenas dígitos.")
+            if len(dado) % 2 != 0:
+                raise ValueError("Intercalado 2 de 5 exige quantidade par de dígitos.")
+
+    def render(self, dado: str, cfg) -> Image.Image:
+        width_px = self._cm_para_px(cfg.barcode_width_cm)
+        height_px = self._cm_para_px(cfg.barcode_height_cm)
+        dado_limpo = dado.strip()
+        modelo = cfg.barcode_model or "code128"
+        if modelo not in self.MODELOS_SUPORTADOS:
+            raise RuntimeError(f"Modelo de código de barras não suportado: {modelo}")
+        self.validar_modelo(dado_limpo, modelo)
+        _rotulo, nome_reportlab = self.MODELOS_SUPORTADOS[modelo]
+
+        try:
+            from reportlab.graphics import renderPM
+            from reportlab.graphics.barcode import createBarcodeDrawing
+            from reportlab.lib.units import mm
+
+            opcoes = {"value": dado_limpo}
+            if nome_reportlab != "ECC200DataMatrix":
+                opcoes.update({"barHeight": 20 * mm, "barWidth": 0.45, "humanReadable": True})
+            desenho = createBarcodeDrawing(nome_reportlab, **opcoes)
+            img = renderPM.drawToPIL(desenho, dpi=self.dpi_padrao).convert("RGB")
+            return ImageResizer.resize_with_ratio(img, width_px, height_px, cfg.keep_barcode_ratio)
+        except Exception as exc:
+            raise RuntimeError(
+                "Geração de código de barras indisponível: habilite o backend renderPM do ReportLab."
+            ) from exc


### PR DESCRIPTION
### Motivation

- Tornar a arquitetura mais modular separando importação de dados e renderização de imagens; e melhorar robustez do preview na UI frente a dependências opcionais. 

### Description

- Extraiu a lógica de importação para `services/data_importer.py` e a renderização para `services/renderers.py` incluindo `QRCodeRenderer`, `BarcodeRenderer` e `ImageResizer`, e atualizou `CodigoService` para orquestrar essas camadas.
- Atualizou a UI em `qr_generator.py` para usar `tk.StringVar` em campos numéricos, adicionou `_parse_float_input` para aceitar vírgula/ponto, e substituiu chamadas diretas de `atualizar_preview` por `solicitar_atualizacao_preview` com debounce (`_preview_after_id`, `preview_debounce_ms`) e handlers de teclado/focus para evitar recalculos excessivos.
- Adicionou verificação de dependências opcionais em `_verificar_dependencias_essenciais` para detectar `reportlab`/`renderPM` e ajustar disponibilidade de exportação para `pdf`/`imprimir` e habilitação do recurso de barcode, além de exibir o status em UI via `dependency_status_var`.
- Várias correções relacionadas: validações preventivas em `_build_config` para bloquear operações quando dependências faltam, tratamento defensivo de presets de etiqueta (corrigido tamanho do preset), parse seguro de margens/espaçamentos e adequações de estado/controle do tipo de código (enable/disable das radios/comboboxes).

### Testing

- Executed the existing automated test suite with `pytest`; the test run completed and all tests passed.
- Ran the application's automated lint/static checks; no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd33972950832aa423bd9f12d91084)