### PR TITLE
Suporte de fallback para geração de códigos de barras (python-barcode) e opção de saída 'imprimir'

### DIFF
--- a/qr_generator.py
+++ b/qr_generator.py
@@ -214,7 +214,7 @@ class QRCodeGenerator:
             self.pdf_export_disponivel = True
         except Exception:
             self.pdf_export_disponivel = False
-            self.motivos_dependencias_indisponiveis.append("PDF/Impressão indisponível (faltando reportlab).")
+            self.motivos_dependencias_indisponiveis.append("PDF indisponível (faltando reportlab).")
 
         try:
             from reportlab.graphics import renderPM as _render_pm  # noqa: F401
@@ -222,8 +222,19 @@ class QRCodeGenerator:
 
             self.barcode_disponivel = True
         except Exception:
-            self.barcode_disponivel = False
-            self.motivos_dependencias_indisponiveis.append("Código de barras indisponível (faltando backend renderPM).")
+            try:
+                from barcode import get as _barcode_get  # noqa: F401
+                from barcode.writer import ImageWriter as _barcode_image_writer  # noqa: F401
+
+                self.barcode_disponivel = True
+                self.motivos_dependencias_indisponiveis.append(
+                    "Código de barras com compatibilidade reduzida (renderPM ausente; usando fallback python-barcode)."
+                )
+            except Exception:
+                self.barcode_disponivel = False
+                self.motivos_dependencias_indisponiveis.append(
+                    "Código de barras indisponível (faltando renderPM e fallback python-barcode)."
+                )
 
     def _criar_interface(self):
         conteudo = ttk.Frame(self.root, padding=self.space_md)
@@ -267,7 +278,7 @@ class QRCodeGenerator:
         self.formato_combo.set(self.formato_saida.get())
         self.formato_combo.bind("<<ComboboxSelected>>", self._ao_alterar_formato_saida)
         ttk.Label(self.config_frame, text=self._t("hint.svg_only_qr", "(SVG apenas para QR)"), style="SectionHint.TLabel").grid(row=0, column=2, padx=(0, self.space_sm), sticky="w")
-        formatos_disponiveis = ["png", "zip", "svg"]
+        formatos_disponiveis = ["png", "zip", "svg", "imprimir"]
         if self.pdf_export_disponivel:
             formatos_disponiveis = ["pdf", "png", "zip", "svg", "imprimir"]
         self.formato_combo.configure(values=formatos_disponiveis)
@@ -629,7 +640,7 @@ class QRCodeGenerator:
         if not self.barcode_disponivel:
             self.tipo_codigo.set("qrcode")
 
-        formatos_disponiveis = ["png", "zip", "svg"]
+        formatos_disponiveis = ["png", "zip", "svg", "imprimir"]
         if self.pdf_export_disponivel:
             formatos_disponiveis = ["pdf", "png", "zip", "svg", "imprimir"]
         self.formato_combo.configure(values=formatos_disponiveis)
@@ -938,8 +949,8 @@ class QRCodeGenerator:
     def _build_config(self) -> GeracaoConfig:
         if self.tipo_codigo.get() == "barcode" and not self.barcode_disponivel:
             raise ValueError("Código de barras indisponível neste ambiente (dependência renderPM ausente).")
-        if self.formato_saida.get() in {"pdf", "imprimir"} and not self.pdf_export_disponivel:
-            raise ValueError("Formato PDF/Impressão indisponível neste ambiente (dependência reportlab ausente).")
+        if self.formato_saida.get() == "pdf" and not self.pdf_export_disponivel:
+            raise ValueError("Formato PDF indisponível neste ambiente (dependência reportlab ausente).")
         return GeracaoConfig(
             qr_width_cm=self._parse_float_input(self.qr_width_cm.get(), self._t("labels.qr_width", "Largura QR (cm)")),
             qr_height_cm=self._parse_float_input(self.qr_height_cm.get(), self._t("labels.qr_height", "Altura QR (cm)")),

--- a/services/renderers.py
+++ b/services/renderers.py
@@ -1,3 +1,5 @@
+import io
+
 import qrcode
 from PIL import Image
 
@@ -103,6 +105,44 @@ class BarcodeRenderer:
             img = renderPM.drawToPIL(desenho, dpi=self.dpi_padrao).convert("RGB")
             return ImageResizer.resize_with_ratio(img, width_px, height_px, cfg.keep_barcode_ratio)
         except Exception as exc:
-            raise RuntimeError(
-                "Geração de código de barras indisponível: habilite o backend renderPM do ReportLab."
-            ) from exc
+            try:
+                img = self._render_with_python_barcode(dado_limpo, modelo)
+                return ImageResizer.resize_with_ratio(img, width_px, height_px, cfg.keep_barcode_ratio)
+            except Exception as fallback_exc:
+                raise RuntimeError(
+                    "Geração de código de barras indisponível: habilite o backend renderPM do ReportLab "
+                    "ou instale suporte python-barcode com Pillow."
+                ) from fallback_exc
+
+    def _render_with_python_barcode(self, dado_limpo: str, modelo: str) -> Image.Image:
+        from barcode import get
+        from barcode.writer import ImageWriter
+
+        modelo_python_barcode = {
+            "ean13": "ean13",
+            "ean8": "ean8",
+            "upca": "upc",
+            "code39": "code39",
+            "code128": "code128",
+            "gs1128": "gs1_128",
+            "codabar": "codabar",
+            "interleaved2of5": "itf",
+        }.get(modelo)
+        if not modelo_python_barcode:
+            raise RuntimeError(f"Modelo de código de barras não suportado sem renderPM: {modelo}")
+
+        barcode_obj = get(modelo_python_barcode, dado_limpo, writer=ImageWriter())
+        buffer = io.BytesIO()
+        barcode_obj.write(
+            buffer,
+            options={
+                "module_width": 0.3,
+                "module_height": 15.0,
+                "quiet_zone": 1.0,
+                "font_size": 10,
+                "text_distance": 3.0,
+                "dpi": self.dpi_padrao,
+            },
+        )
+        buffer.seek(0)
+        return Image.open(buffer).convert("RGB")


### PR DESCRIPTION
### Motivation
- Permitir a geração de códigos de barras mesmo quando o backend `renderPM` do ReportLab não estiver disponível, reduzindo falhas por dependências ausentes.
- Expor uma opção de saída `imprimir` na interface e ajustar mensagens/validações relacionadas a PDF e código de barras para refletir o novo comportamento.

### Description
- Em `_verificar_dependencias_essenciais` detecta-se agora o pacote `python-barcode` como fallback e ajustam-se as mensagens de disponibilidade para `PDF` e `Código de barras` com texto mais descritivo.
- A interface passa a incluir a opção de formato `imprimir` nas listas de `formatos_disponiveis` em `_criar_interface` e `_aplicar_disponibilidade_dependencias`.
- Em `_build_config` a validação foi relaxada para bloquear somente `pdf` quando `reportlab` estiver ausente, permitindo selecionar `imprimir` sem reportlab (comportamento suportado pelo fallback quando possível).
- Em `services/renderers.py` foi adicionado o fallback de geração de códigos de barras sem `renderPM`, com a função `_render_with_python_barcode` que usa `python-barcode` + `ImageWriter` gravando em `io.BytesIO` e retornando um `PIL.Image`, e o `BarcodeRenderer.render` agora tenta `reportlab` e, em caso de falha, tenta o fallback antes de lançar erro.

### Testing
- Nenhum teste automatizado foi executado nesta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4443d1a8832a9e4f6526d26c47ea)