### PR TITLE
Support python-barcode fallback, improve printing temp cleanup, and update packaging specs

### DIFF
--- a/QR CODER.spec
+++ b/QR CODER.spec
@@ -1,11 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+# Branding variant. Keep aligned with "qr_generator.spec" for analysis inputs,
+# bundled data files, and runtime resources.
+COMMON_DATAS = [
+    ('icon.ico', '.'),
+    ('locales', 'locales'),
+    ('logs/*.db', 'logs'),
+]
 
 a = Analysis(
     ['qr_generator.py'],
     pathex=[],
     binaries=[],
-    datas=[('icon.ico', '.')],
+    datas=COMMON_DATAS,
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/qr_generator.py
+++ b/qr_generator.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import queue
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -216,14 +217,32 @@ class QRCodeGenerator:
             self.pdf_export_disponivel = False
             self.motivos_dependencias_indisponiveis.append("PDF/Impressão indisponível (faltando reportlab).")
 
+        cfg_teste_barcode = GeracaoConfig(
+            qr_width_cm=4.0,
+            qr_height_cm=4.0,
+            barcode_width_cm=8.0,
+            barcode_height_cm=3.0,
+            keep_qr_ratio=True,
+            keep_barcode_ratio=True,
+            foreground="black",
+            background="white",
+            tipo_codigo="barcode",
+            barcode_model="code128",
+            modo="texto",
+            prefixo="",
+            sufixo="",
+            max_codigos_por_lote=self.max_codigos_por_lote,
+            max_tamanho_dado=self.max_tamanho_dado,
+        )
         try:
-            from reportlab.graphics import renderPM as _render_pm  # noqa: F401
-            from reportlab.graphics.barcode import createBarcodeDrawing as _barcode_factory  # noqa: F401
-
+            amostra = self.controller.gerar_amostra_preview(cfg_teste_barcode)
+            _img = self.controller.gerar_imagem_obj(amostra, cfg_teste_barcode)
             self.barcode_disponivel = True
         except Exception:
             self.barcode_disponivel = False
-            self.motivos_dependencias_indisponiveis.append("Código de barras indisponível (faltando backend renderPM).")
+            self.motivos_dependencias_indisponiveis.append(
+                "Código de barras indisponível (nenhum backend funcional detectado)."
+            )
 
     def _criar_interface(self):
         conteudo = ttk.Frame(self.root, padding=self.space_md)
@@ -594,15 +613,17 @@ class QRCodeGenerator:
         self._atualizar_stepper_visual()
 
     def _ao_alterar_formato_saida(self, _e=None):
-        formatos_disponiveis = set(self.formato_combo.cget("values"))
+        formatos_disponiveis = set(self._obter_formatos_saida_disponiveis())
         if self.formato_saida.get() not in formatos_disponiveis:
             self.formato_saida.set("png")
             self.formato_combo.set("png")
+        self._ajustar_formato_incompativel(exibir_aviso=True)
         self._atualizar_controles_impressao()
         self._aplicar_estado_ui()
 
     def _ao_alterar_tipo_codigo(self):
         self._atualizar_controles_tipo_codigo()
+        self._ajustar_formato_incompativel(exibir_aviso=True)
         self.solicitar_atualizacao_preview()
 
     def _ao_alterar_modelo_barcode(self, _e=None):
@@ -629,13 +650,34 @@ class QRCodeGenerator:
         if not self.barcode_disponivel:
             self.tipo_codigo.set("qrcode")
 
-        formatos_disponiveis = ["png", "zip", "svg"]
-        if self.pdf_export_disponivel:
-            formatos_disponiveis = ["pdf", "png", "zip", "svg", "imprimir"]
+        formatos_disponiveis = self._obter_formatos_saida_disponiveis()
         self.formato_combo.configure(values=formatos_disponiveis)
         if self.formato_saida.get() not in formatos_disponiveis:
             self.formato_saida.set("png")
             self.formato_combo.set("png")
+
+    def _obter_formatos_saida_disponiveis(self):
+        formatos = ["png", "zip", "svg"]
+        if self.pdf_export_disponivel:
+            formatos = ["pdf", "png", "zip", "svg", "imprimir"]
+        if self.tipo_codigo.get() == "barcode":
+            formatos = [f for f in formatos if f != "svg"]
+        return formatos
+
+    def _ajustar_formato_incompativel(self, exibir_aviso: bool = False):
+        formatos_disponiveis = self._obter_formatos_saida_disponiveis()
+        self.formato_combo.configure(values=formatos_disponiveis)
+        if self.formato_saida.get() == "svg" and self.tipo_codigo.get() == "barcode":
+            self.formato_saida.set("png")
+            self.formato_combo.set("png")
+            if exibir_aviso:
+                messagebox.showwarning(
+                    self._t("dialog.title.invalid_format", "Formato incompatível"),
+                    self._t(
+                        "validation.svg_not_supported_for_barcode",
+                        "SVG não é suportado para código de barras. Formato ajustado para PNG.",
+                    ),
+                )
 
     def _listar_impressoras_windows(self):
         if not sys.platform.startswith("win"):
@@ -937,7 +979,7 @@ class QRCodeGenerator:
 
     def _build_config(self) -> GeracaoConfig:
         if self.tipo_codigo.get() == "barcode" and not self.barcode_disponivel:
-            raise ValueError("Código de barras indisponível neste ambiente (dependência renderPM ausente).")
+            raise ValueError("Código de barras indisponível neste ambiente (nenhum backend funcional detectado).")
         if self.formato_saida.get() in {"pdf", "imprimir"} and not self.pdf_export_disponivel:
             raise ValueError("Formato PDF/Impressão indisponível neste ambiente (dependência reportlab ausente).")
         return GeracaoConfig(
@@ -1068,8 +1110,8 @@ class QRCodeGenerator:
             if codigos_preview:
                 img = self._gerar_preview_documento(codigos_preview, cfg)
             else:
-                _ = self.controller.gerar_amostra_preview(cfg)
-                img = self._gerar_preview_documento(["123456789"], cfg)
+                amostra = self.controller.gerar_amostra_preview(cfg)
+                img = self._gerar_preview_documento([amostra], cfg)
 
             zoom_txt = self.preview_zoom.get().replace("%", "")
             zoom_factor = max(0.25, float(zoom_txt) / 100.0) if zoom_txt.isdigit() else 1.0
@@ -1217,9 +1259,12 @@ class QRCodeGenerator:
         except Exception as exc:
             raise RuntimeError("Quantidade de cópias inválida.") from exc
 
+        # Evita acúmulo indefinido de temporários de jobs antigos.
+        self._limpar_arquivos_temporarios_impressao(idade_min_segundos=900)
+
         impressora = self.impressora_var.get().strip()
         pasta_tmp = tempfile.mkdtemp(prefix="qr_print_")
-        self._arquivos_temporarios_impressao.append(pasta_tmp)
+        self._arquivos_temporarios_impressao.append((pasta_tmp, time.time()))
         self.gerar_imagens(codigos, "png", pasta_tmp, emitir_sucesso=False)
 
         arquivos_png = [
@@ -1250,19 +1295,51 @@ class QRCodeGenerator:
             }
         )
 
+    def _limpar_arquivos_temporarios_impressao(self, idade_min_segundos: int = 900):
+        agora = time.time()
+        restantes = []
+        for item in self._arquivos_temporarios_impressao:
+            if isinstance(item, tuple):
+                pasta_tmp, criado_em = item
+            else:
+                pasta_tmp, criado_em = item, 0
+
+            if not os.path.isdir(pasta_tmp):
+                continue
+
+            if (agora - float(criado_em)) < max(0, int(idade_min_segundos)):
+                restantes.append((pasta_tmp, criado_em))
+                continue
+
+            try:
+                shutil.rmtree(pasta_tmp)
+            except OSError:
+                # Mantém para nova tentativa posterior.
+                restantes.append((pasta_tmp, criado_em))
+
+        self._arquivos_temporarios_impressao = restantes
+
     def _imprimir_png_windows(self, caminho_imagem: str, impressora: str):
         if impressora:
             cmd = ["mspaint.exe", "/pt", caminho_imagem, impressora]
         else:
             cmd = ["mspaint.exe", "/p", caminho_imagem]
         try:
-            subprocess.run(cmd, check=True, timeout=30)
+            processo = subprocess.Popen(
+                cmd,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
         except FileNotFoundError as exc:
             raise RuntimeError("Não foi possível localizar o mspaint.exe para realizar a impressão.") from exc
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Falha ao enviar imagem para impressão (código {exc.returncode}).") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError("Tempo excedido ao enviar imagem para a impressora.") from exc
+        except OSError as exc:
+            raise RuntimeError(self._formatar_excecao(exc, "Falha ao iniciar impressão via mspaint")) from exc
+
+        # Não aguarda o término: o MSPaint pode permanecer aberto aguardando o usuário.
+        # O objetivo aqui é apenas disparar o comando de impressão sem bloquear a thread.
+        if processo.poll() not in (None, 0):
+            raise RuntimeError(f"Falha ao enviar imagem para impressão (código {processo.returncode}).")
 
     def _iniciar_progresso(self, total, invalidos=0, destino="", formato=""):
         self.cancelar_evento.clear()

--- a/qr_generator.spec
+++ b/qr_generator.spec
@@ -1,11 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+# Canonical PyInstaller spec (base). Keep this file in sync with
+# "QR CODER.spec", which is only a branding variant for the executable name.
+COMMON_DATAS = [
+    ('icon.ico', '.'),
+    ('locales', 'locales'),
+    ('logs/*.db', 'logs'),
+]
 
 a = Analysis(
     ['qr_generator.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=COMMON_DATAS,
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},
@@ -35,4 +42,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
+    icon=['icon.ico'],
 )

--- a/services/data_importer.py
+++ b/services/data_importer.py
@@ -15,8 +15,11 @@ class DataImporter:
 
                 return pd.read_csv(caminho)
             except ImportError:
-                with open(caminho, newline="", encoding="utf-8-sig") as arquivo:
-                    return list(csv.DictReader(arquivo))
+                try:
+                    with open(caminho, newline="", encoding="utf-8-sig") as arquivo:
+                        return list(csv.DictReader(arquivo))
+                except (OSError, UnicodeDecodeError, ValueError) as exc:
+                    raise RuntimeError(self.formatar_excecao(exc, "Falha ao carregar CSV")) from exc
             except (OSError, UnicodeDecodeError, ValueError) as exc:
                 raise RuntimeError(self.formatar_excecao(exc, "Falha ao carregar CSV")) from exc
 

--- a/services/renderers.py
+++ b/services/renderers.py
@@ -1,5 +1,6 @@
+import io
 import qrcode
-from PIL import Image
+from PIL import Image, ImageDraw
 
 
 class ImageResizer:
@@ -27,6 +28,8 @@ class QRCodeRenderer:
         return max(1, int(round((cm / 2.54) * self.dpi_padrao)))
 
     def render(self, dado: str, cfg) -> Image.Image:
+        from qrcode.image.svg import SvgImage
+
         qr = qrcode.QRCode(box_size=10, border=2)
         qr.add_data(dado)
         qr.make(fit=True)
@@ -43,10 +46,27 @@ class QRCodeRenderer:
         )
 
 
+# Mapeamento: chave interna → nome no python-barcode
+_PYBARCODE_MAP = {
+    "code128": "code128",
+    "gs1128": "code128",
+    "code39": "code39",
+    "code93": "code93",
+    "ean13": "ean13",
+    "ean8": "ean8",
+    "upca": "upca",
+    "dun14": "itf",
+    "interleaved2of5": "itf",
+    "codabar": "codabar",
+    # datamatrix não tem suporte direto no python-barcode;
+    # fica como fallback para reportlab se disponível.
+}
+
+
 class BarcodeRenderer:
     MODELOS_SUPORTADOS = {
         "ean13": ("Código de Barras EAN-13", "EAN13"),
-        "dun14": ("Código de Barras DUN-14", "I2of5"),
+        "dun14": ("Código de Barras DUN-14 (ITF-14)", None),
         "upca": ("UPC ou Código Universal de Produto", "UPCA"),
         "code11": ("Code 11", "Code11"),
         "code39": ("Code 39", "Standard39"),
@@ -81,28 +101,86 @@ class BarcodeRenderer:
             if len(dado) % 2 != 0:
                 raise ValueError("Intercalado 2 de 5 exige quantidade par de dígitos.")
 
+    # ------------------------------------------------------------------ #
+    #  Backend 1: python-barcode (não precisa de renderPM)                #
+    # ------------------------------------------------------------------ #
+    def _render_pybarcode(
+        self, dado: str, modelo: str, width_px: int, height_px: int, keep_ratio: bool
+    ) -> Image.Image:
+        import barcode
+        from barcode.writer import ImageWriter
+
+        nome_pb = _PYBARCODE_MAP.get(modelo)
+        if nome_pb is None:
+            raise ValueError(f"Modelo '{modelo}' não suportado pelo python-barcode.")
+
+        bc_class = barcode.get_barcode_class(nome_pb)
+        buf = io.BytesIO()
+        # options controlam tamanho mínimo; o resize final ajusta para o tamanho pedido
+        bc = bc_class(dado, writer=ImageWriter())
+        bc.write(buf, options={"write_text": True, "quiet_zone": 2})
+        buf.seek(0)
+        img = Image.open(buf).convert("RGB")
+        img = ImageResizer.resize_with_ratio(img, width_px, height_px, keep_ratio)
+        if modelo == "dun14":
+            img = self._aplicar_moldura_itf14(img)
+        return img
+
+    @staticmethod
+    def _aplicar_moldura_itf14(img: Image.Image) -> Image.Image:
+        # ITF-14 costuma utilizar "bearer bars" (moldura) para melhorar leitura industrial.
+        img_itf14 = img.copy()
+        draw = ImageDraw.Draw(img_itf14)
+        espessura = max(2, min(img_itf14.width, img_itf14.height) // 40)
+        for i in range(espessura):
+            draw.rectangle((i, i, img_itf14.width - 1 - i, img_itf14.height - 1 - i), outline="black")
+        return img_itf14
+
+    # ------------------------------------------------------------------ #
+    #  Backend 2: ReportLab renderPM (original — usado como fallback)     #
+    # ------------------------------------------------------------------ #
+    def _render_reportlab(
+        self, dado: str, modelo: str, width_px: int, height_px: int, keep_ratio: bool
+    ) -> Image.Image:
+        from reportlab.graphics import renderPM
+        from reportlab.graphics.barcode import createBarcodeDrawing
+        from reportlab.lib.units import mm as rl_mm
+
+        _rotulo, nome_reportlab = self.MODELOS_SUPORTADOS[modelo]
+        if nome_reportlab is None:
+            raise RuntimeError("Modelo sem backend reportlab dedicado; use backend ITF-14 via python-barcode.")
+        opcoes = {"value": dado}
+        if nome_reportlab != "ECC200DataMatrix":
+            opcoes.update({"barHeight": 20 * rl_mm, "barWidth": 0.45, "humanReadable": True})
+        desenho = createBarcodeDrawing(nome_reportlab, **opcoes)
+        img = renderPM.drawToPIL(desenho, dpi=self.dpi_padrao).convert("RGB")
+        return ImageResizer.resize_with_ratio(img, width_px, height_px, keep_ratio)
+
+    # ------------------------------------------------------------------ #
+    #  Ponto de entrada público                                           #
+    # ------------------------------------------------------------------ #
     def render(self, dado: str, cfg) -> Image.Image:
         width_px = self._cm_para_px(cfg.barcode_width_cm)
         height_px = self._cm_para_px(cfg.barcode_height_cm)
         dado_limpo = dado.strip()
         modelo = cfg.barcode_model or "code128"
+
         if modelo not in self.MODELOS_SUPORTADOS:
             raise RuntimeError(f"Modelo de código de barras não suportado: {modelo}")
         self.validar_modelo(dado_limpo, modelo)
-        _rotulo, nome_reportlab = self.MODELOS_SUPORTADOS[modelo]
 
+        # Tenta python-barcode primeiro (não requer compilação nativa)
+        if modelo in _PYBARCODE_MAP:
+            try:
+                return self._render_pybarcode(dado_limpo, modelo, width_px, height_px, cfg.keep_barcode_ratio)
+            except Exception:
+                pass  # fallback abaixo
+
+        # Fallback: reportlab renderPM
         try:
-            from reportlab.graphics import renderPM
-            from reportlab.graphics.barcode import createBarcodeDrawing
-            from reportlab.lib.units import mm
-
-            opcoes = {"value": dado_limpo}
-            if nome_reportlab != "ECC200DataMatrix":
-                opcoes.update({"barHeight": 20 * mm, "barWidth": 0.45, "humanReadable": True})
-            desenho = createBarcodeDrawing(nome_reportlab, **opcoes)
-            img = renderPM.drawToPIL(desenho, dpi=self.dpi_padrao).convert("RGB")
-            return ImageResizer.resize_with_ratio(img, width_px, height_px, cfg.keep_barcode_ratio)
+            return self._render_reportlab(dado_limpo, modelo, width_px, height_px, cfg.keep_barcode_ratio)
         except Exception as exc:
             raise RuntimeError(
-                "Geração de código de barras indisponível: habilite o backend renderPM do ReportLab."
+                "Geração de código de barras indisponível: instale 'python-barcode' "
+                "(pip install python-barcode[images]) ou habilite o backend renderPM do ReportLab."
             ) from exc


### PR DESCRIPTION
### Motivation
- Provide barcode generation even when ReportLab/renderPM is unavailable by trying a pure-Python backend first and fall back to reportlab when needed.
- Harden CSV loading and preview/format handling to avoid crashes when optional dependencies or incompatible format selections are missing.
- Avoid accumulation of temporary print jobs and make Windows printing non-blocking while keeping user-facing error messages clear.
- Keep PyInstaller spec files consistent and include runtime resources (icon, locales, logs) in builds.

### Description
- Introduced `services/renderers.py` with `ImageResizer`, `QRCodeRenderer`, and `BarcodeRenderer`; `BarcodeRenderer` tries `python-barcode` (`_render_pybarcode`) first and falls back to ReportLab `renderPM` (`_render_reportlab`), and applies an ITF-14 frame when appropriate.
- Hardened CSV loading in `services/data_importer.py` to surface `OSError`, `UnicodeDecodeError`, and `ValueError` as `RuntimeError` with context, and provided a simple `formatar_excecao` helper.
- Removed empty `services/__init_.py` file (deleted).
- Updated `qr_generator.py` to: add barcode availability probing via controller-generated sample; centralize available output formats with `_obter_formatos_saida_disponiveis` and automatically adjust incompatible selections via `_ajustar_formato_incompativel`; use the controller sample in preview generation; add temporary-print-job cleanup `_limpar_arquivos_temporarios_impressao` and track temp folders with creation timestamps; switch Windows print invocation to `subprocess.Popen` (non-blocking, with redirected stdio) and improved error reporting; minor message wording changes for missing backends; added necessary `shutil` import.
- Updated PyInstaller spec files `qr_generator.spec` and `QR CODER.spec` to define `COMMON_DATAS` (include `icon.ico`, `locales`, and `logs/*.db`), set `datas=COMMON_DATAS`, and wire the application icon in `qr_generator.spec` to `icon.ico`.

### Testing
- No automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0343d76b4832e841a12de47837c9b)