### PR TITLE
Add GDI print diagnostics, printer DC metrics and diagnostic tests

### DIFF
--- a/qr_generator.py
+++ b/qr_generator.py
@@ -1484,6 +1484,33 @@ class QRCodeGenerator:
             alvo_h = max(1, int(round(altura_cm * 10.0 * ppmm_y)))
 
             dib = ImageWin.Dib(img)
+            metricas = {
+                "impressora": nome_impressora,
+                "horzsize_mm": horzsize_mm,
+                "vertsize_mm": vertsize_mm,
+                "horzres_px": horzres_px,
+                "vertres_px": vertres_px,
+                "ppmm_x": round(ppmm_x, 4),
+                "ppmm_y": round(ppmm_y, 4),
+                "largura_solicitada_cm": largura_cm,
+                "altura_solicitada_cm": altura_cm,
+                "alvo_w_px": alvo_w,
+                "alvo_h_px": alvo_h,
+                "img_original_w_px": img.width,
+                "img_original_h_px": img.height,
+                "razao_w": round(alvo_w / img.width, 4) if img.width else 0,
+                "razao_h": round(alvo_h / img.height, 4) if img.height else 0,
+                "alvo_w_mm_calculado": round(alvo_w / ppmm_x, 2) if ppmm_x else 0,
+                "alvo_h_mm_calculado": round(alvo_h / ppmm_y, 2) if ppmm_y else 0,
+            }
+            self.logger.info(
+                "Diagnóstico de impressão GDI",
+                extra={
+                    "event": "print_gdi_metrics",
+                    "operation": "imprimir_gdi",
+                    **metricas,
+                },
+            )
             dib.draw(hdc.GetHandleOutput(), (0, 0, alvo_w, alvo_h))
 
             hdc.EndPage()
@@ -1492,6 +1519,53 @@ class QRCodeGenerator:
             return True
         except Exception as exc:
             raise RuntimeError(self._formatar_excecao(exc, "Falha ao imprimir via driver do Windows")) from exc
+
+    def _obter_metricas_impressora_dc(self, nome_impressora: str) -> dict:
+        """Retorna métricas físicas do DC da impressora sem imprimir nada.
+
+        Usado nos testes diagnósticos. Retorna dict vazio se pywin32 não
+        estiver disponível ou se a impressora não for encontrada.
+        """
+        try:
+            import win32con
+            import win32ui
+        except ImportError:
+            return {}
+
+        hdc = win32ui.CreateDC()
+        try:
+            hdc.CreatePrinterDC(nome_impressora)
+            horzsize_mm = max(1, hdc.GetDeviceCaps(win32con.HORZSIZE))
+            vertsize_mm = max(1, hdc.GetDeviceCaps(win32con.VERTSIZE))
+            horzres_px  = max(1, hdc.GetDeviceCaps(win32con.HORZRES))
+            vertres_px  = max(1, hdc.GetDeviceCaps(win32con.VERTRES))
+            logpixelsx  = max(1, hdc.GetDeviceCaps(win32con.LOGPIXELSX))
+            logpixelsy  = max(1, hdc.GetDeviceCaps(win32con.LOGPIXELSY))
+            physoffx    = hdc.GetDeviceCaps(win32con.PHYSICALOFFSETX)
+            physoffy    = hdc.GetDeviceCaps(win32con.PHYSICALOFFSETY)
+            physwidth   = hdc.GetDeviceCaps(win32con.PHYSICALWIDTH)
+            physheight  = hdc.GetDeviceCaps(win32con.PHYSICALHEIGHT)
+            return {
+                "horzsize_mm":  horzsize_mm,
+                "vertsize_mm":  vertsize_mm,
+                "horzres_px":   horzres_px,
+                "vertres_px":   vertres_px,
+                "logpixelsx":   logpixelsx,
+                "logpixelsy":   logpixelsy,
+                "physicaloffsetx": physoffx,
+                "physicaloffsety": physoffy,
+                "physicalwidth":   physwidth,
+                "physicalheight":  physheight,
+                "ppmm_x": round(horzres_px / horzsize_mm, 4),
+                "ppmm_y": round(vertres_px / vertsize_mm, 4),
+            }
+        except Exception:
+            return {}
+        finally:
+            try:
+                hdc.DeleteDC()
+            except Exception:
+                pass
 
     def _iniciar_progresso(self, total, invalidos=0, destino="", formato=""):
         self.cancelar_evento.clear()

--- a/tests/test_print_size_diagnostics.py
+++ b/tests/test_print_size_diagnostics.py
@@ -1,0 +1,139 @@
+import os
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from models.geracao_config import GeracaoConfig
+from qr_generator import QRCodeGenerator
+
+
+def _cfg(**kwargs):
+    base = dict(
+        qr_width_cm=4.0, qr_height_cm=4.0,
+        barcode_width_cm=8.0, barcode_height_cm=3.0,
+        keep_qr_ratio=True, keep_barcode_ratio=True,
+        foreground="black", background="white",
+        tipo_codigo="barcode", barcode_model="code128",
+        modo="texto", prefixo="", sufixo="",
+        etiqueta_width_mm=100.0, etiqueta_height_mm=60.0,
+        max_codigos_por_lote=5000, max_tamanho_dado=512,
+    )
+    base.update(kwargs)
+    return GeracaoConfig(**base)
+
+
+def _make_png_bytes(w: int, h: int) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", (w, h), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestSuspeitoA_KeepRatio:
+    def test_barcode_com_keep_ratio_true_canvas_tem_tamanho_correto(self):
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0, keep_barcode_ratio=True)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+        esperado_w = max(1, round((8.0 / 2.54) * DPI))
+        esperado_h = max(1, round((3.0 / 2.54) * DPI))
+        assert img.width == esperado_w
+        assert img.height == esperado_h
+
+    def test_barcode_com_keep_ratio_false_canvas_tem_tamanho_correto(self):
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0, keep_barcode_ratio=False)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+        esperado_w = max(1, round((8.0 / 2.54) * DPI))
+        esperado_h = max(1, round((3.0 / 2.54) * DPI))
+        assert img.width == esperado_w
+        assert img.height == esperado_h
+
+
+class TestSuspeitoB_DpiMetadata:
+    def test_png_gerado_sem_dpi_metadata(self):
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        img_lido = Image.open(buf)
+        dpi_info = img_lido.info.get("dpi")
+        if dpi_info is not None:
+            assert abs(dpi_info[0] - DPI) < 5
+
+    def test_tamanho_fisico_se_interpretado_como_96dpi(self):
+        DPI_GERACAO = 200
+        DPI_FALLBACK = 96
+        largura_cm = 8.0
+        altura_cm = 3.0
+        px_w = round((largura_cm / 2.54) * DPI_FALLBACK)
+        px_h = round((altura_cm / 2.54) * DPI_FALLBACK)
+        cm_impresso_w = (px_w / DPI_FALLBACK) * 2.54
+        cm_impresso_h = (px_h / DPI_FALLBACK) * 2.54
+        assert cm_impresso_w < largura_cm
+        assert cm_impresso_h < altura_cm
+
+
+class TestSuspeitoC_CalculoGDI:
+    @pytest.mark.parametrize("horzsize_mm,horzres_px,largura_cm,esperado_px", [
+        (104, 832, 8.0, 640),
+        (104, 832, 4.0, 320),
+        (104, 832, 10.4, 832),
+    ])
+    def test_formula_cm_para_px(self, horzsize_mm, horzres_px, largura_cm, esperado_px):
+        ppmm_x = horzres_px / horzsize_mm
+        alvo_w = max(1, int(round(largura_cm * 10.0 * ppmm_x)))
+        assert alvo_w == esperado_px
+
+
+class TestSuspeitoD_LoggingEMetricas:
+    def test_logging_diagnostico_antes_do_draw(self, tmp_path):
+        img_path = tmp_path / "t.png"
+        Image.new("RGB", (100, 50), "white").save(img_path)
+
+        app = QRCodeGenerator.__new__(QRCodeGenerator)
+        app.logger = MagicMock()
+        app._formatar_excecao = lambda exc, m: f"{m}: {exc}"
+
+        fake_dc = MagicMock()
+        fake_dc.GetDeviceCaps.side_effect = [104, 60, 832, 480]
+
+        fake_con = SimpleNamespace(HORZSIZE=1, VERTSIZE=2, HORZRES=3, VERTRES=4)
+        fake_print = SimpleNamespace(GetDefaultPrinter=lambda: "ELGIN")
+        fake_ui = SimpleNamespace(CreateDC=lambda: fake_dc)
+        fake_dib = MagicMock()
+
+        with patch("importlib.import_module", side_effect=[fake_con, fake_print, fake_ui]), \
+             patch("PIL.ImageWin.Dib", return_value=fake_dib):
+            ok = app._imprimir_png_windows_gdi(str(img_path), "ELGIN", 8.0, 3.0)
+
+        assert ok is True
+        app.logger.info.assert_called_once()
+        assert fake_dib.draw.called
+
+    def test_obter_metricas_dc_retorna_dict(self):
+        app = QRCodeGenerator.__new__(QRCodeGenerator)
+        hdc = MagicMock()
+        hdc.GetDeviceCaps.side_effect = [104, 60, 832, 480, 203, 203, 0, 0, 832, 480]
+        fake_con = SimpleNamespace(
+            HORZSIZE=1, VERTSIZE=2, HORZRES=3, VERTRES=4,
+            LOGPIXELSX=5, LOGPIXELSY=6,
+            PHYSICALOFFSETX=7, PHYSICALOFFSETY=8,
+            PHYSICALWIDTH=9, PHYSICALHEIGHT=10,
+        )
+        fake_ui = SimpleNamespace(CreateDC=lambda: hdc)
+        with patch.dict("sys.modules", {"win32con": fake_con, "win32ui": fake_ui}):
+            out = app._obter_metricas_impressora_dc("ELGIN")
+        assert out["horzsize_mm"] == 104
+        assert out["horzres_px"] == 832
+        assert out["ppmm_x"] == 8.0
+


### PR DESCRIPTION
### Motivation
- Diagnosticar perda de escala na cadeia de impressão Windows GDI para a impressora ELGIN L42PRO, capturando valores reportados pelo driver e pontos de transformação que afetam o tamanho impresso.
- Expor métricas do DC da impressora para permitir testes automatizados e reduzir suposições matemáticas sobre `HORZSIZE`/`HORZRES` e outros caps.

### Description
- Adicionado bloco de logging estruturado imediatamente antes de `dib.draw()` em `_imprimir_png_windows_gdi` que registra `event=print_gdi_metrics` com todas as métricas solicitadas sem alterar o fluxo de impressão existente.
- Implementado o novo método público de instância `def _obter_metricas_impressora_dc(self, nome_impressora: str) -> dict` que cria um DC, lê apenas `GetDeviceCaps` e retorna um dicionário defensivo (ou `{}` quando `pywin32` não está disponível ou ocorre erro), sem chamar `StartDoc`/`StartPage`.
- Adicionada suíte de testes diagnósticos em `tests/test_print_size_diagnostics.py` cobrindo: comportamento de `keep_barcode_ratio`, metadata DPI em PNG, fórmula cm→px usada no caminho GDI, invocação de logging diagnóstico e retorno das métricas do DC.

### Testing
- Executado `pytest -q tests/test_print_size_diagnostics.py` e a suíte passou com sucesso (todos os testes verdes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d1e2530832eab1c22a74e0cf245)