### PR TITLE
Log GDI print metrics, add printer-DC metrics helper, fix tempfile handling in tests, and add print-size diagnostics tests

### DIFF
--- a/qr_generator.py
+++ b/qr_generator.py
@@ -1484,6 +1484,33 @@ class QRCodeGenerator:
             alvo_h = max(1, int(round(altura_cm * 10.0 * ppmm_y)))
 
             dib = ImageWin.Dib(img)
+            metricas = {
+                "impressora": nome_impressora,
+                "horzsize_mm": horzsize_mm,
+                "vertsize_mm": vertsize_mm,
+                "horzres_px": horzres_px,
+                "vertres_px": vertres_px,
+                "ppmm_x": round(ppmm_x, 4),
+                "ppmm_y": round(ppmm_y, 4),
+                "largura_solicitada_cm": largura_cm,
+                "altura_solicitada_cm": altura_cm,
+                "alvo_w_px": alvo_w,
+                "alvo_h_px": alvo_h,
+                "img_original_w_px": img.width,
+                "img_original_h_px": img.height,
+                "razao_w": round(alvo_w / img.width, 4) if img.width else 0,
+                "razao_h": round(alvo_h / img.height, 4) if img.height else 0,
+                "alvo_w_mm_calculado": round(alvo_w / ppmm_x, 2) if ppmm_x else 0,
+                "alvo_h_mm_calculado": round(alvo_h / ppmm_y, 2) if ppmm_y else 0,
+            }
+            self.logger.info(
+                "Diagnóstico de impressão GDI",
+                extra={
+                    "event": "print_gdi_metrics",
+                    "operation": "imprimir_gdi",
+                    **metricas,
+                },
+            )
             dib.draw(hdc.GetHandleOutput(), (0, 0, alvo_w, alvo_h))
 
             hdc.EndPage()
@@ -1492,6 +1519,53 @@ class QRCodeGenerator:
             return True
         except Exception as exc:
             raise RuntimeError(self._formatar_excecao(exc, "Falha ao imprimir via driver do Windows")) from exc
+
+    def _obter_metricas_impressora_dc(self, nome_impressora: str) -> dict:
+        """Retorna métricas físicas do DC da impressora sem imprimir nada.
+
+        Usado nos testes diagnósticos. Retorna dict vazio se pywin32 não
+        estiver disponível ou se a impressora não for encontrada.
+        """
+        try:
+            import win32con
+            import win32ui
+        except ImportError:
+            return {}
+
+        hdc = win32ui.CreateDC()
+        try:
+            hdc.CreatePrinterDC(nome_impressora)
+            horzsize_mm = max(1, hdc.GetDeviceCaps(win32con.HORZSIZE))
+            vertsize_mm = max(1, hdc.GetDeviceCaps(win32con.VERTSIZE))
+            horzres_px  = max(1, hdc.GetDeviceCaps(win32con.HORZRES))
+            vertres_px  = max(1, hdc.GetDeviceCaps(win32con.VERTRES))
+            logpixelsx  = max(1, hdc.GetDeviceCaps(win32con.LOGPIXELSX))
+            logpixelsy  = max(1, hdc.GetDeviceCaps(win32con.LOGPIXELSY))
+            physoffx    = hdc.GetDeviceCaps(win32con.PHYSICALOFFSETX)
+            physoffy    = hdc.GetDeviceCaps(win32con.PHYSICALOFFSETY)
+            physwidth   = hdc.GetDeviceCaps(win32con.PHYSICALWIDTH)
+            physheight  = hdc.GetDeviceCaps(win32con.PHYSICALHEIGHT)
+            return {
+                "horzsize_mm":  horzsize_mm,
+                "vertsize_mm":  vertsize_mm,
+                "horzres_px":   horzres_px,
+                "vertres_px":   vertres_px,
+                "logpixelsx":   logpixelsx,
+                "logpixelsy":   logpixelsy,
+                "physicaloffsetx": physoffx,
+                "physicaloffsety": physoffy,
+                "physicalwidth":   physwidth,
+                "physicalheight":  physheight,
+                "ppmm_x": round(horzres_px / horzsize_mm, 4),
+                "ppmm_y": round(vertres_px / vertsize_mm, 4),
+            }
+        except Exception:
+            return {}
+        finally:
+            try:
+                hdc.DeleteDC()
+            except Exception:
+                pass
 
     def _iniciar_progresso(self, total, invalidos=0, destino="", formato=""):
         self.cancelar_evento.clear()

--- a/tests/test_data_importer.py
+++ b/tests/test_data_importer.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -15,14 +16,13 @@ def imp():
 
 def _csv(dados, encoding="utf-8"):
     fd, caminho = tempfile.mkstemp(suffix=".csv")
-    Path(caminho).unlink(missing_ok=True)
+    os.close(fd)
     cols = list(dados.keys())
-    rows = zip(*[dados[c] for c in cols])
+    rows = list(zip(*[dados[c] for c in cols])) if any(dados.values()) else []
     with open(caminho, "w", newline="", encoding=encoding) as f:
         w = csv.writer(f)
         w.writerow(cols)
-        for row in rows:
-            w.writerow(row)
+        w.writerows(rows)
     return caminho
 
 
@@ -30,7 +30,7 @@ def _xlsx(dados):
     pytest.importorskip("openpyxl")
     pd = pytest.importorskip("pandas")
     fd, caminho = tempfile.mkstemp(suffix=".xlsx")
-    Path(caminho).unlink(missing_ok=True)
+    os.close(fd)
     pd.DataFrame(dados).to_excel(caminho, index=False)
     return caminho
 

--- a/tests/test_integracao.py
+++ b/tests/test_integracao.py
@@ -188,8 +188,10 @@ class TestGeracaoSVG:
         assert len(list(tmp_path.glob("*.svg"))) == 1
 
     def test_svg_com_barcode_lanca_erro(self, app, tmp_path):
+        pytest.importorskip("barcode")
         app.tipo_codigo.set("barcode")
         app.barcode_model.set("code128")
+        app.barcode_disponivel = True
         with pytest.raises(RuntimeError, match="SVG"):
             app.gerar_imagens(["x"], "svg", str(tmp_path), emitir_sucesso=False)
 

--- a/tests/test_print_size_diagnostics.py
+++ b/tests/test_print_size_diagnostics.py
@@ -1,0 +1,214 @@
+import os
+import sys
+import tempfile
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from PIL import Image
+
+from models.geracao_config import GeracaoConfig
+
+
+# ─────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────
+
+def _cfg(**kwargs):
+    base = dict(
+        qr_width_cm=4.0, qr_height_cm=4.0,
+        barcode_width_cm=8.0, barcode_height_cm=3.0,
+        keep_qr_ratio=True, keep_barcode_ratio=True,
+        foreground="black", background="white",
+        tipo_codigo="barcode", barcode_model="code128",
+        modo="texto", prefixo="", sufixo="",
+        etiqueta_width_mm=100.0, etiqueta_height_mm=60.0,
+        max_codigos_por_lote=5000, max_tamanho_dado=512,
+    )
+    base.update(kwargs)
+    return GeracaoConfig(**base)
+
+
+def _make_png_bytes(w: int, h: int) -> bytes:
+    """PNG em memória sem DPI metadata."""
+    buf = BytesIO()
+    Image.new("RGB", (w, h), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _make_png_with_dpi(w: int, h: int, dpi: int) -> bytes:
+    """PNG em memória COM DPI metadata."""
+    buf = BytesIO()
+    img = Image.new("RGB", (w, h), "white")
+    img.save(buf, format="PNG", dpi=(dpi, dpi))
+    return buf.getvalue()
+
+
+# ─────────────────────────────────────────────────────────────────
+# GRUPO 1 — Suspeito A: keep_barcode_ratio encolhe o barcode visível
+# ─────────────────────────────────────────────────────────────────
+
+class TestSuspeitoA_KeepRatio:
+
+    def test_barcode_com_keep_ratio_true_canvas_tem_tamanho_correto(self):
+        pytest.importorskip("barcode")
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0,
+                   keep_barcode_ratio=True)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+        esperado_w = max(1, round((8.0 / 2.54) * DPI))
+        esperado_h = max(1, round((3.0 / 2.54) * DPI))
+        assert img.width == esperado_w, (
+            f"Largura do PNG: {img.width}px, esperado {esperado_w}px. "
+            f"keep_ratio está encolhendo o canvas?"
+        )
+        assert img.height == esperado_h, (
+            f"Altura do PNG: {img.height}px."
+        )
+
+    def test_barcode_com_keep_ratio_false_canvas_tem_tamanho_correto(self):
+        pytest.importorskip("barcode")
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0,
+                   keep_barcode_ratio=False)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+        esperado_w = max(1, round((8.0 / 2.54) * DPI))
+        esperado_h = max(1, round((3.0 / 2.54) * DPI))
+        assert img.width == esperado_w
+        assert img.height == esperado_h
+
+    def test_barcode_area_util_vs_canvas_com_keep_ratio(self):
+        pytest.importorskip("barcode")
+        from services.renderers import BarcodeRenderer
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0,
+                   keep_barcode_ratio=True)
+        r = BarcodeRenderer(dpi_padrao=200)
+        img = r.render("ABC123", cfg)
+        pixels = list(img.getdata())
+        brancos = sum(1 for p in pixels if p == (255, 255, 255))
+        total = len(pixels)
+        pct_branco = brancos / total * 100
+        print(f"\n[DIAGNÓSTICO A] Canvas {img.width}×{img.height}px, "
+              f"{pct_branco:.1f}% pixels brancos (padding)")
+        assert total > 0
+
+
+class TestSuspeitoB_DpiMetadata:
+
+    def test_png_gerado_sem_dpi_metadata(self):
+        pytest.importorskip("barcode")
+        from services.renderers import BarcodeRenderer
+        DPI = 200
+        cfg = _cfg(barcode_width_cm=8.0, barcode_height_cm=3.0)
+        r = BarcodeRenderer(dpi_padrao=DPI)
+        img = r.render("ABC123", cfg)
+
+        buf = BytesIO()
+        img.save(buf, format="PNG")
+        buf.seek(0)
+        img_lido = Image.open(buf)
+        dpi_info = img_lido.info.get("dpi")
+
+        if dpi_info is None:
+            print(f"\n[DIAGNÓSTICO B] PNG salvo SEM DPI metadata. "
+                  f"Fallback do Windows usará 96 DPI → imagem impressa "
+                  f"será {img.width/96*2.54:.1f}cm × {img.height/96*2.54:.1f}cm "
+                  f"em vez de {8.0}cm × {3.0}cm.")
+        else:
+            print(f"\n[DIAGNÓSTICO B] PNG salvo COM DPI metadata: {dpi_info}")
+            assert abs(dpi_info[0] - DPI) < 5, (
+                f"DPI no metadata é {dpi_info[0]}, esperado {DPI}"
+            )
+
+
+class TestSuspeitoD_LoggingEMetricas:
+    """Verifica o cálculo do retângulo GDI sem dependências de módulos nativos."""
+
+    def test_calculo_alvo_px_isolado(self):
+        """Testa a fórmula ppmm × cm × 10 sem qualquer mock de módulo nativo."""
+        casos = [
+            (104, 832,  8.0, 640),
+            (104, 832,  4.0, 320),
+            (104, 832, 10.4, 832),
+        ]
+        for horzsize_mm, horzres_px, largura_cm, esperado_px in casos:
+            ppmm_x = horzres_px / horzsize_mm
+            alvo_w = max(1, int(round(largura_cm * 10.0 * ppmm_x)))
+            assert alvo_w == esperado_px, (
+                f"horzsize={horzsize_mm}mm horzres={horzres_px}px "
+                f"largura={largura_cm}cm → alvo={alvo_w}px esperado={esperado_px}px"
+            )
+
+    def test_retangulo_origin_zero(self):
+        """O retângulo passado para Dib.draw deve sempre iniciar em (0, 0)."""
+        horzsize_mm, horzres_px = 104, 832
+        largura_cm, altura_cm = 8.0, 3.0
+        ppmm_x = horzres_px / horzsize_mm
+        ppmm_y = ppmm_x
+        alvo_w = max(1, int(round(largura_cm * 10.0 * ppmm_x)))
+        alvo_h = max(1, int(round(altura_cm * 10.0 * ppmm_y)))
+        retangulo = (0, 0, alvo_w, alvo_h)
+        assert retangulo[0] == 0, "x inicial deve ser 0"
+        assert retangulo[1] == 0, "y inicial deve ser 0"
+        assert retangulo[2] == alvo_w
+        assert retangulo[3] == alvo_h
+
+    def test_tamanho_fisico_invertido_deve_bater(self):
+        """Inversão: alvo_px / ppmm deve retornar os mm originais (erro < 0.5mm)."""
+        horzsize_mm = 104
+        horzres_px  = 832
+        largura_cm  = 8.0
+        ppmm_x = horzres_px / horzsize_mm
+        alvo_w = max(1, int(round(largura_cm * 10.0 * ppmm_x)))
+        mm_calculado = alvo_w / ppmm_x
+        assert abs(mm_calculado - largura_cm * 10.0) < 0.5, (
+            f"Tamanho físico calculado: {mm_calculado:.2f}mm, "
+            f"esperado: {largura_cm*10:.2f}mm"
+        )
+
+    @pytest.mark.windows_only
+    def test_obter_metricas_impressora_retorna_dict(self):
+        """Verifica que _obter_metricas_impressora_dc retorna estrutura correta."""
+        tk = pytest.importorskip("tkinter")
+        try:
+            root = tk.Tk()
+            root.withdraw()
+        except Exception:
+            pytest.skip("Requer display tkinter")
+
+        from qr_generator import QRCodeGenerator
+        from unittest.mock import MagicMock
+        app = QRCodeGenerator(root)
+        app.root.after = MagicMock()
+
+        impressoras = list(app.impressora_combo["values"])
+        if not impressoras:
+            pytest.skip("Nenhuma impressora encontrada")
+
+        for nome in impressoras:
+            metricas = app._obter_metricas_impressora_dc(nome)
+            if not metricas:
+                continue
+            chaves_obrigatorias = {
+                "horzsize_mm", "vertsize_mm", "horzres_px",
+                "vertres_px", "ppmm_x", "ppmm_y",
+            }
+            assert chaves_obrigatorias.issubset(metricas.keys()), (
+                f"Chaves ausentes: {chaves_obrigatorias - metricas.keys()}"
+            )
+            assert metricas["horzsize_mm"] > 0
+            assert metricas["horzres_px"] > 0
+            dpi_eq = metricas["ppmm_x"] * 25.4
+            print(f"\n[DIAGNÓSTICO DC REAL] {nome}: "
+                  f"HORZSIZE={metricas['horzsize_mm']}mm "
+                  f"HORZRES={metricas['horzres_px']}px "
+                  f"DPI_equiv={dpi_eq:.1f}")
+            assert 50 < dpi_eq < 1200, (
+                f"DPI equivalente fora do range: {dpi_eq:.1f}"
+            )
+        root.destroy()


### PR DESCRIPTION
### Motivation
- Add runtime diagnostics and structured logging for Windows GDI printing to help investigate size discrepancies when printing images.
- Provide a helper to read physical/virtual printer DC metrics without performing a print so tests can validate device characteristics.
- Fix test helpers that used temporary file paths incorrectly on Windows and add diagnostic tests to reproduce and assert sizing/DPI behaviours.

### Description
- Emit a structured `print_gdi_metrics` log with printer/DC metrics and calculated pixel targets before calling `Dib.draw` in `QRCodeGenerator.imprimir_via_driver_windows`.
- Add `_obter_metricas_impressora_dc` to `QRCodeGenerator` to safely query printer DC caps via `pywin32` and return a metrics `dict` with fallbacks and safe cleanup.
- Update test helpers in `tests/test_data_importer.py` to `close` the tempfile file descriptor, handle empty CSV rows correctly, and use `writerows` to write CSVs, and similarly close temp files when creating XLSX fixtures to avoid permission issues on Windows.
- Tweak an integration test in `tests/test_integracao.py` to `importorskip(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f29d1e2530832eab1c22a74e0cf245)