### PR TITLE
Expose AppController.service to fix AttributeError in generation flows

### DIFF
--- a/app_controller.py
+++ b/app_controller.py
@@ -24,6 +24,10 @@ class AppController:
     def metrics_store(self):
         return self.deps.metrics_store
 
+    @property
+    def service(self):
+        return self.deps.service
+
     def t(self, key: str, default: str = "", **kwargs) -> str:
         return self.deps.i18n.t(key, default, **kwargs)
 


### PR DESCRIPTION
### Motivation
- Restaurar compatibilidade com pontos do app que acessam `self.controller.service` (fluxos de geração de imagem/PDF/ZIP/impressão) que estavam lançando `AttributeError` porque `service` estava apenas em `deps`.

### Description
- Adicionada a propriedade `service` em `AppController` que retorna `self.deps.service`, permitindo que chamadas existentes continuem funcionando sem alterar os chamadores.

### Testing
- Executado `python -m py_compile app_controller.py` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4d2cf4fc832abffde4cd87cf7414)