### PR TITLE
Add lote management feature: UI, controller, persistence, XML importer and tests

### DIFF
--- a/locales/pt_BR.json
+++ b/locales/pt_BR.json
@@ -69,5 +69,13 @@
   "validation.no_valid_codes_for_print": "Nenhum código válido encontrado para impressão.",
   "error.open_output_folder": "Não foi possível abrir a pasta de saída:\n{erro}",
   "info.generated_files_in": "Arquivo(s) gerado(s) em: {caminho}",
-  "error.open_file_failed": "Não foi possível abrir o arquivo: {erro}"
+  "error.open_file_failed": "Não foi possível abrir o arquivo: {erro}",
+  "lote.app.title": "Gestão de Lotes Industriais",
+  "lote.button.generate": "Gerar Lote",
+  "lote.button.open": "Abrir Lote",
+  "lote.button.view": "Exibir Lote",
+  "lote.button.report": "Relatório",
+  "lote.status.draft": "rascunho",
+  "lote.status.confirmed": "confirmado",
+  "lote.status.printed": "impresso"
 }

--- a/lote_app.py
+++ b/lote_app.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+from lote_controller import LoteController
+
+
+class LoteApp:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.controller = LoteController()
+        self.root.title("Gestão de Lotes Industriais")
+        self._configurar_estilos()
+        self._build_main()
+        self._refresh_lotes()
+
+    def _configurar_estilos(self):
+        style = ttk.Style(self.root)
+        style.configure("Primary.TButton", padding=(16, 10), font=("Segoe UI", 10, "bold"))
+        style.map("Primary.TButton", foreground=[("!disabled", "white")], background=[("!disabled", "#2563eb")])
+        style.configure("Secondary.TButton", padding=(12, 10), font=("Segoe UI", 10, "bold"))
+        style.map("Secondary.TButton", foreground=[("!disabled", "#374151")], background=[("!disabled", "#e5e7eb")])
+        style.configure("App.TCombobox", padding=(6, 4))
+        style.configure("App.TSpinbox", padding=(6, 4))
+        style.configure("App.TEntry", padding=(6, 4))
+
+    def _build_main(self):
+        top = ttk.Frame(self.root)
+        top.pack(fill="x")
+        ttk.Button(top, text="Gerar Lote", style="Primary.TButton", command=self._abrir_gerar_lote).pack(side="left", padx=4, pady=6)
+        ttk.Button(top, text="Abrir Lote", style="Secondary.TButton", command=self._abrir_lote).pack(side="left", padx=4)
+        ttk.Button(top, text="Exibir Lote", style="Secondary.TButton", command=self._exibir_lote).pack(side="left", padx=4)
+        ttk.Button(top, text="Relatório", style="Secondary.TButton", command=self._abrir_relatorio).pack(side="left", padx=4)
+        self.tree = ttk.Treeview(self.root, columns=("ident", "criado", "nf", "qtd", "status"), show="headings")
+        for c, t in [("ident", "IDENT"), ("criado", "Criação"), ("nf", "NF Ref."), ("qtd", "Qtd. itens"), ("status", "Status")]:
+            self.tree.heading(c, text=t)
+        self.tree.pack(fill="both", expand=True)
+        self.status = ttk.Label(self.root, text="Pronto")
+        self.status.pack(fill="x", side="bottom")
+
+    def _refresh_lotes(self):
+        for i in self.tree.get_children():
+            self.tree.delete(i)
+        self.lotes = self.controller.listar_lotes()
+        for lote in self.lotes:
+            self.tree.insert("", "end", iid=lote.id, values=(lote.ident, lote.criado_em[:19], lote.nf_referencia, len(lote.itens), lote.status))
+        self.status.config(text=f"Total de lotes: {len(self.lotes)}")
+
+    def _abrir_gerar_lote(self):
+        caminho = filedialog.askopenfilename(filetypes=[("XML", "*.xml")])
+        if not caminho:
+            return
+        try:
+            itens = self.controller.importar_xml(caminho)
+        except ValueError as exc:
+            messagebox.showerror("Erro", str(exc))
+            return
+        lote = self.controller.criar_lote(1, 2026, itens[0].nf_numero, "122", itens)
+        self.controller.reimprimir_lote(lote)
+        self.controller.atualizar_status(lote.id, "impresso")
+        self._refresh_lotes()
+        messagebox.showinfo("Sucesso", f"Lote {lote.ident} criado e enviado para impressão.")
+
+    def _abrir_lote(self):
+        self._exibir_lote()
+
+    def _exibir_lote(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        lote = next((l for l in self.lotes if l.id == sel[0]), None)
+        if not lote:
+            return
+        win = tk.Toplevel(self.root)
+        win.title(f"Lote {lote.ident}")
+        ttk.Label(win, text=f"Status: {lote.status}").pack(anchor="w")
+        tv = ttk.Treeview(win, columns=("cod", "desc", "qty", "nf", "ger"), show="headings")
+        for c in ("cod", "desc", "qty", "nf", "ger"):
+            tv.heading(c, text=c)
+        tv.pack(fill="both", expand=True)
+        for i in lote.itens:
+            tv.insert("", "end", values=(i.cod_item, i.descr_item, i.qty, i.nf_numero, i.cod_gerado))
+        ttk.Button(win, text="Imprimir novamente", command=lambda: self.controller.reimprimir_lote(lote)).pack()
+
+    def _abrir_relatorio(self):
+        win = tk.Toplevel(self.root)
+        win.title("Relatório")
+        ttk.Label(win, text="Relatório de lotes").pack()

--- a/lote_controller.py
+++ b/lote_controller.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from app_controller import AppController
+from models.geracao_config import GeracaoConfig
+from models.lote import Lote
+from services.lote_service import LoteService
+from services.lote_store import LoteStore
+from services.xml_importer import importar_itens_nfe
+
+
+class LoteController:
+    def __init__(self):
+        self.store = LoteStore()
+        self.service = LoteService(self.store)
+
+    def importar_xml(self, caminho_xml: str):
+        return importar_itens_nfe(caminho_xml)
+
+    def criar_lote(self, mes_rec: int, ano_rec: int, nf_ref: str, ano_nf: str, itens):
+        return self.service.criar_lote(mes_rec, ano_rec, nf_ref, ano_nf, itens)
+
+    def listar_lotes(self):
+        return self.store.listar_lotes()
+
+    def atualizar_status(self, lote_id: str, status: str):
+        self.store.atualizar_status(lote_id, status)
+
+    def reimprimir_lote(self, lote: Lote):
+        return self._imprimir_codigos([i.cod_gerado for i in lote.itens])
+
+    def _imprimir_codigos(self, codigos: list[str]):
+        ctrl = AppController.build_default()
+        cfg = GeracaoConfig(4.0, 4.0, 8.0, 3.0, True, True, "black", "white", "barcode", "code128", "texto", "", "", 100.0, 60.0)
+        validos, _invalidos = ctrl.preparar_codigos([{"cod": c} for c in codigos], "cod", cfg)
+        pasta = Path(tempfile.mkdtemp(prefix="lote_print_"))
+        arquivos = []
+        for idx, dado in enumerate(validos, 1):
+            img = ctrl.gerar_imagem_obj(dado, cfg)
+            out = pasta / f"codigo_{idx:03d}.png"
+            img.save(out)
+            arquivos.append(str(out))
+        return arquivos

--- a/main_lote.py
+++ b/main_lote.py
@@ -1,0 +1,9 @@
+import tkinter as tk
+
+from lote_app import LoteApp
+
+
+if __name__ == "__main__":
+    root = tk.Tk()
+    app = LoteApp(root)
+    root.mainloop()

--- a/models/lote.py
+++ b/models/lote.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ItemLote:
+    cod_item: str
+    descr_item: str
+    qty: int
+    nf_numero: str
+    cod_gerado: str = ""
+
+
+@dataclass
+class Lote:
+    id: str
+    ident: str
+    seq_lote: int
+    mes_rec: int
+    ano_rec: int
+    nf_referencia: str
+    itens: list[ItemLote] = field(default_factory=list)
+    criado_em: str = ""
+    status: str = "rascunho"

--- a/services/lote_service.py
+++ b/services/lote_service.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
+from models.lote import Lote, ItemLote
+from services.lote_store import LoteStore
+
+
+class LoteService:
+    def __init__(self, store: LoteStore):
+        self.store = store
+
+    @staticmethod
+    def gerar_ident(seq_lote: int, mes_rec: int, ano_rec: int, nf_ref: str, ano_nf: str) -> str:
+        return f"L{seq_lote:02d}{mes_rec:02d}{str(ano_rec)[-2:]}{str(nf_ref)[-3:]:>03}{str(ano_nf)[-3:]}"
+
+    def proximo_seq_lote(self, mes_rec: int, ano_rec: int) -> int:
+        return self.store.proximo_seq_lote(mes_rec, ano_rec)
+
+    def criar_lote(self, mes_rec: int, ano_rec: int, nf_referencia: str, ano_nf: str, itens: list[ItemLote]) -> Lote:
+        seq = self.proximo_seq_lote(mes_rec, ano_rec)
+        ident = self.gerar_ident(seq, mes_rec, ano_rec, nf_referencia, ano_nf)
+        lote_id = str(uuid.uuid4())
+        for i, item in enumerate(itens, start=1):
+            item.cod_gerado = f"{ident}_{i:03d}"
+        lote = Lote(id=lote_id, ident=ident, seq_lote=seq, mes_rec=mes_rec, ano_rec=int(str(ano_rec)[-2:]), nf_referencia=nf_referencia, itens=itens, criado_em=datetime.now().isoformat(), status="confirmado")
+        self.store.criar_lote(lote)
+        return lote

--- a/services/lote_store.py
+++ b/services/lote_store.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+from models.lote import ItemLote, Lote
+
+
+class LoteStore:
+    def __init__(self, db_path: str = "logs/lotes.db"):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self):
+        return sqlite3.connect(self.db_path)
+
+    def _init_db(self):
+        with self._connect() as conn:
+            conn.execute("""
+            CREATE TABLE IF NOT EXISTS lotes (
+                id TEXT PRIMARY KEY,
+                ident TEXT UNIQUE,
+                seq_lote INTEGER,
+                mes_rec INTEGER,
+                ano_rec INTEGER,
+                nf_referencia TEXT,
+                criado_em TEXT,
+                status TEXT
+            )""")
+            conn.execute("""
+            CREATE TABLE IF NOT EXISTS itens_lote (
+                id TEXT PRIMARY KEY,
+                lote_id TEXT,
+                cod_item TEXT,
+                descr_item TEXT,
+                qty INTEGER,
+                nf_numero TEXT,
+                cod_gerado TEXT,
+                FOREIGN KEY(lote_id) REFERENCES lotes(id)
+            )""")
+
+    def criar_lote(self, lote: Lote) -> str:
+        with self._connect() as conn:
+            conn.execute("INSERT INTO lotes VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (lote.id, lote.ident, lote.seq_lote, lote.mes_rec, lote.ano_rec, lote.nf_referencia, lote.criado_em, lote.status))
+            for item in lote.itens:
+                conn.execute("INSERT INTO itens_lote VALUES (?, ?, ?, ?, ?, ?, ?)", (str(uuid.uuid4()), lote.id, item.cod_item, item.descr_item, item.qty, item.nf_numero, item.cod_gerado))
+        return lote.id
+
+    def listar_lotes(self) -> list[Lote]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT id FROM lotes ORDER BY criado_em DESC").fetchall()
+        return [self.obter_lote(r[0]) for r in rows if self.obter_lote(r[0])]
+
+    def obter_lote(self, id: str) -> Lote | None:
+        with self._connect() as conn:
+            row = conn.execute("SELECT id, ident, seq_lote, mes_rec, ano_rec, nf_referencia, criado_em, status FROM lotes WHERE id=?", (id,)).fetchone()
+            if not row:
+                return None
+            itens_rows = conn.execute("SELECT cod_item, descr_item, qty, nf_numero, cod_gerado FROM itens_lote WHERE lote_id=?", (id,)).fetchall()
+        itens = [ItemLote(*r) for r in itens_rows]
+        return Lote(id=row[0], ident=row[1], seq_lote=row[2], mes_rec=row[3], ano_rec=row[4], nf_referencia=row[5], criado_em=row[6], status=row[7], itens=itens)
+
+    def atualizar_status(self, id: str, status: str):
+        with self._connect() as conn:
+            conn.execute("UPDATE lotes SET status=? WHERE id=?", (status, id))
+
+    def proximo_seq_lote(self, mes_rec: int, ano_rec: int) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COALESCE(MAX(seq_lote), 0) FROM lotes WHERE mes_rec=? AND ano_rec=?", (mes_rec, ano_rec)).fetchone()
+        return int(row[0]) + 1
+
+    def deletar_lote(self, id: str):
+        with self._connect() as conn:
+            conn.execute("DELETE FROM itens_lote WHERE lote_id=?", (id,))
+            conn.execute("DELETE FROM lotes WHERE id=?", (id,))

--- a/services/xml_importer.py
+++ b/services/xml_importer.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Iterable
+
+from models.lote import ItemLote
+
+NFE_NS = {"nfe": "http://www.portalfiscal.inf.br/nfe"}
+
+
+def _round_qty(value: str) -> int:
+    return int(round(float(value)))
+
+
+def importar_itens_nfe(caminho_xml: str) -> list[ItemLote]:
+    try:
+        root = ET.parse(caminho_xml).getroot()
+    except Exception as exc:
+        raise ValueError(f"XML inválido: {exc}") from exc
+
+    inf_nfe = root.find(".//nfe:infNFe", NFE_NS)
+    if inf_nfe is None:
+        raise ValueError("XML inválido: estrutura NF-e (<infNFe>) não encontrada.")
+
+    n_nf = inf_nfe.findtext("nfe:ide/nfe:nNF", default="", namespaces=NFE_NS).strip()
+    if not n_nf:
+        raise ValueError("XML inválido: número da NF (<nNF>) não encontrado.")
+
+    itens: list[ItemLote] = []
+    for det in inf_nfe.findall("nfe:det", NFE_NS):
+        cprod = (det.findtext("nfe:prod/nfe:cProd", default="", namespaces=NFE_NS) or "").strip()
+        xprod = (det.findtext("nfe:prod/nfe:xProd", default="", namespaces=NFE_NS) or "").strip()
+        qcom = (det.findtext("nfe:prod/nfe:qCom", default="0", namespaces=NFE_NS) or "0").strip()
+        try:
+            qty = _round_qty(qcom)
+        except Exception as exc:
+            raise ValueError(f"XML inválido: quantidade inválida no item '{xprod or cprod}'.") from exc
+        itens.append(ItemLote(cod_item=cprod, descr_item=xprod, qty=qty, nf_numero=n_nf, cod_gerado=""))
+
+    if not itens:
+        raise ValueError("XML inválido: nenhum item <det> encontrado na NF-e.")
+
+    filtrados = [i for i in itens if any(k in i.descr_item.upper() for k in ("INJET", "BOMB"))]
+    return filtrados or itens

--- a/tests/test_lote_service.py
+++ b/tests/test_lote_service.py
@@ -1,0 +1,20 @@
+from models.lote import ItemLote
+from services.lote_service import LoteService
+from services.lote_store import LoteStore
+
+
+def test_gerar_ident_casos():
+    assert LoteService.gerar_ident(1, 1, 2026, "011", "122") == "L010126011122"
+    assert LoteService.gerar_ident(12, 11, 26, "9999", "2026") == "L121126999026"
+
+
+def test_seq_crud_status(tmp_path):
+    store = LoteStore(str(tmp_path / "lotes.db"))
+    service = LoteService(store)
+    assert service.proximo_seq_lote(1, 26) == 1
+    lote = service.criar_lote(1, 2026, "011", "122", [ItemLote("1", "INJETOR", 2, "011")])
+    assert store.proximo_seq_lote(1, 26) == 2
+    lotes = store.listar_lotes()
+    assert len(lotes) == 1
+    store.atualizar_status(lote.id, "impresso")
+    assert store.obter_lote(lote.id).status == "impresso"

--- a/tests/test_xml_importer.py
+++ b/tests/test_xml_importer.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from services.xml_importer import importar_itens_nfe
+
+
+def _write_xml(tmp_path: Path, body: str) -> str:
+    p = tmp_path / "nfe.xml"
+    p.write_text(body, encoding="utf-8")
+    return str(p)
+
+
+def test_xml_valido_retorna_itens(tmp_path):
+    xml = """<nfeProc xmlns=\"http://www.portalfiscal.inf.br/nfe\"><NFe><infNFe><ide><nNF>123</nNF></ide><det><prod><cProd>A1</cProd><xProd>INJETOR X</xProd><qCom>2.4</qCom></prod></det></infNFe></NFe></nfeProc>"""
+    itens = importar_itens_nfe(_write_xml(tmp_path, xml))
+    assert len(itens) == 1
+    assert itens[0].qty == 2
+
+
+def test_filtro_e_fallback(tmp_path):
+    xml = """<nfeProc xmlns=\"http://www.portalfiscal.inf.br/nfe\"><NFe><infNFe><ide><nNF>123</nNF></ide><det><prod><cProd>A1</cProd><xProd>parafuso</xProd><qCom>1</qCom></prod></det><det><prod><cProd>A2</cProd><xProd>BOMBA d\'agua</xProd><qCom>3</qCom></prod></det></infNFe></NFe></nfeProc>"""
+    itens = importar_itens_nfe(_write_xml(tmp_path, xml))
+    assert len(itens) == 1
+    xml2 = """<nfeProc xmlns=\"http://www.portalfiscal.inf.br/nfe\"><NFe><infNFe><ide><nNF>123</nNF></ide><det><prod><cProd>A1</cProd><xProd>parafuso</xProd><qCom>1</qCom></prod></det></infNFe></NFe></nfeProc>"""
+    itens2 = importar_itens_nfe(_write_xml(tmp_path, xml2))
+    assert len(itens2) == 1
+
+
+def test_xml_invalido(tmp_path):
+    p = tmp_path / "x.xml"
+    p.write_text("<x></x>", encoding="utf-8")
+    with pytest.raises(ValueError):
+        importar_itens_nfe(str(p))


### PR DESCRIPTION
### Motivation
- Provide a simple lot (lote) management flow to import NF-e XMLs, create/manage lots and reprint generated codes using existing generation workflow.
- Persist lot and item data locally so created lots can be listed, inspected and have their status updated.

### Description
- Add models for `Lote` and `ItemLote` in `models/lote.py` and a `LoteService` in `services/lote_service.py` that generates identifiers and assigns generated codes to items.
- Implement `LoteStore` in `services/lote_store.py` using SQLite for CRUD on lots and items and sequence generation with `proximo_seq_lote`.
- Add `services/xml_importer.py` to parse NF-e XMLs, round quantities, validate structure and filter items by keywords (with a fallback to all items).
- Provide a `LoteController` (`lote_controller.py`) that wires store/service and uses `AppController` to render code images for reprinting, plus a Tkinter UI `LoteApp` (`lote_app.py`) and `main_lote.py` entrypoint to interact with the feature, and add localized strings in `locales/pt_BR.json`.

### Testing
- Added unit tests `tests/test_lote_service.py` and `tests/test_xml_importer.py` that exercise identifier generation, sequence handling, CRUD/status updates and XML parsing/filters.
- Ran `pytest` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038e735cbc832a9568e943a0d3f977)